### PR TITLE
Remove "quick test of our credentials by listing our authorization server(s)"

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -23,17 +23,6 @@ func (c *Config) loadAndValidate() error {
 		return fmt.Errorf("[ERROR] Error creating Okta client: %v", err)
 	}
 
-	// quick test of our credentials by listing our authorization server(s)
-	url := fmt.Sprintf("authorizationServers")
-	req, err := client.NewRequest("GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error initializing test connect to Okta: %v", err)
-	}
-	_, err = client.Do(req, nil)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error testing connection to Okta. Please verify your credentials: %v", err)
-	}
-
 	// add our client object to Config
 	c.oktaClient = client
 	return nil


### PR DESCRIPTION
This endpoint is not available in production accounts afaik. I tried to hit it with curl and get this response:
```json
{
    "errorCode": "E0000015",
    "errorSummary": "You do not have permission to access the feature you are requesting",
    "errorLink": "E0000015",
    "errorId": "oaeb5YyiMOGRPO7C4wZSNt1MA",
    "errorCauses": []
}
```