### PR TITLE
Better error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ terraform.tfstate
 terraform.tfstate.backup
 terraform.log
 crash.log
-terraform-provider-okta
+terraform-provider-okta*
 
 # go dep vendor directory
 vendor/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,7 +42,7 @@
   revision = "d9e68af06061e643439a2f61815a15596e608a91"
 
 [[projects]]
-  digest = "1:8d4209442e95a75e4d69c218ede547f81086ed4fe4a6e73a617caf95ec22ce12"
+  digest = "1:7ce89ed8d316001962c8be34bd815288e4acf3ce98b077cc6d9dad93b6a9dd2b"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -78,8 +78,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "505514fea21d88b799f6fbef79fb0c0b108e3437"
-  version = "v1.15.17"
+  revision = "e21dfa909e14ce93f88f1f3505764bc4952a11be"
+  version = "v1.15.18"
 
 [[projects]]
   branch = "master"
@@ -507,11 +507,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a3f00ac457c955fe86a41e1495e8f4c54cb5399d609374c5cc26aa7d72e542c8"
+  digest = "1:4dcdb3f7c22f5f048de7c7ad5b72c4547d63bfb4923da15538d0051d553b2ef8"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "3b58ed4ad3395d483fc92d5d14123ce2c3581fec"
+  revision = "11551d06cbcc94edc80a0facaccbda56473c19c1"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"

--- a/okta/resource_identity_provider.go
+++ b/okta/resource_identity_provider.go
@@ -270,10 +270,12 @@ func resourceIdentityProviderCreate(d *schema.ResourceData, m interface{}) error
 
 	returnedIdp, _, err := client.IdentityProviders.CreateIdentityProvider(idp)
 
-	d.SetId(returnedIdp.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("[ERROR] %v.", err)
 	}
+
+  d.SetId(returnedIdp.ID)
+
 	return resourceIdentityProviderRead(d, m)
 }
 

--- a/okta/resource_identity_provider.go
+++ b/okta/resource_identity_provider.go
@@ -274,7 +274,7 @@ func resourceIdentityProviderCreate(d *schema.ResourceData, m interface{}) error
 		return fmt.Errorf("[ERROR] %v.", err)
 	}
 
-  d.SetId(returnedIdp.ID)
+	d.SetId(returnedIdp.ID)
 
 	return resourceIdentityProviderRead(d, m)
 }


### PR DESCRIPTION
Was getting a `panic: runtime error: invalid memory address or nil pointer dereference` error on the `okta_identity_provider` resource due to a `You do not have permission to access the feature you are requesting` error we were receiving from okta.  Needed to move the `d.SetId(returnedIdp.ID)` after the error check and then surface the error to terraform during the apply to make it more clear what was going on there.