### PR TITLE
add idp importer function

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-VERSION=v1.1.3
+VERSION=v1.1.4
 
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,12 +15,12 @@ build: fmtcheck build-macos build-linux
 build-macos:
 	GOOS=darwin GOARCH=amd64 go build -o terraform-provider-okta_${VERSION}
 	mkdir -p ~/.terraform.d/plugins/darwin_amd64/
-	cp terraform-provider-okta_${VERSION} ~/.terraform.d/plugins/darwin_amd64/
+	mv terraform-provider-okta_${VERSION} ~/.terraform.d/plugins/darwin_amd64/
 
 build-linux:
 	GOOS=linux GOARCH=amd64 go build -o terraform-provider-okta_${VERSION}
 	mkdir -p ~/.terraform.d/plugins/linux_amd64/
-	cp terraform-provider-okta_${VERSION} ~/.terraform.d/plugins/linux_amd64/
+	mv terraform-provider-okta_${VERSION} ~/.terraform.d/plugins/linux_amd64/
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/okta/resource_identity_provider.go
+++ b/okta/resource_identity_provider.go
@@ -15,6 +15,9 @@ func resourceIdentityProviders() *schema.Resource {
 		Update: resourceIdentityProviderUpdate,
 		Delete: resourceIdentityProviderDelete,
 		Exists: idpExists,
+		Importer: &schema.ResourceImporter{
+			State: resourceOktaIdentityProviderImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"active": &schema.Schema{
@@ -411,4 +414,11 @@ func idpExists(d *schema.ResourceData, m interface{}) (bool, error) {
 		return false, fmt.Errorf("[ERROR] Error Listing Identity Provider in Okta: %v", err)
 	}
 	return true, nil
+}
+
+func resourceOktaIdentityProviderImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceIdentityProviderRead(d, meta); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/okta/resource_identity_provider.go
+++ b/okta/resource_identity_provider.go
@@ -326,7 +326,7 @@ func resourceIdentityProviderRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("policy_provisioning_profile_master", idp.Policy.Provisioning.ProfileMaster)
 	d.Set("policy_provisioning_groups_action", idp.Policy.Provisioning.Groups.Action)
 
-	if _, ok := d.GetOk("policy_provisioning_group_assignments"); ok {
+	if len(idp.Policy.Provisioning.Groups.Assignments) > 0 {
 		d.Set("policy_provisioning_group_assignments", idp.Policy.Provisioning.Groups.Assignments)
 	}
 


### PR DESCRIPTION
give the `okta_identity_provider` resource the ability to get imported from existing resources in okta back to state.

testing this import locally revealed that I should be using the length of the returned `idp.Policy.Provisioning.Groups.Assignments` slice of strings to determine if `policy_provisioning_group_assignments` should be getting set in state.  using `terraform import` showed this was missing in state even though it existed on the resource because import is just using the read function.