### PR TITLE
change scopes to Required in okta_trusted_origin resource

### DIFF
--- a/okta/resource_trusted_origin.go
+++ b/okta/resource_trusted_origin.go
@@ -37,7 +37,7 @@ func resourceTrustedOrigin() *schema.Resource {
 			},
 			"scopes": &schema.Schema{
 				Type:        schema.TypeList,
-				Optional:    true,
+				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "Scopes of the Trusted Origin - can either be CORS or REDIRECT only",
 			},


### PR DESCRIPTION
the `scopes` parameter in the `okta_trusted_origin` resource isn't Optional; updating it to be Required in the Terraform schema