### PR TITLE
allow custom profile attributes to be set on an okta user

### DIFF
--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -45,8 +45,8 @@ func resourceUser() *schema.Resource {
 				Description: "User country code",
 			},
 			"custom_profile_attributes": &schema.Schema{
-				Type:          schema.TypeMap,
-				Optional:      true,
+				Type:     schema.TypeMap,
+				Optional: true,
 			},
 			"department": &schema.Schema{
 				Type:        schema.TypeString,
@@ -368,4 +368,3 @@ func resourceUserExists(d *schema.ResourceData, m interface{}) (bool, error) {
 
 	return true, nil
 }
-

--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -3,9 +3,7 @@ package okta
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -46,6 +44,10 @@ func resourceUser() *schema.Resource {
 				Optional:    true,
 				Description: "User country code",
 			},
+			"custom_profile_attributes": &schema.Schema{
+				Type:          schema.TypeMap,
+				Optional:      true,
+			},
 			"department": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -63,12 +65,9 @@ func resourceUser() *schema.Resource {
 			},
 			"email": &schema.Schema{
 				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "User primary email address. Default = user login",
+				Required:     true,
+				Description:  "User primary email address",
 				ValidateFunc: matchEmailRegexp,
-				// supress diff if no email value is given since it defauls to login
-				// and it's technically required by Okta
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool { return new == "" },
 			},
 			"employee_number": &schema.Schema{
 				Type:        schema.TypeString,
@@ -256,18 +255,6 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] List User %v", d.Get("login").(string))
 	client := m.(*Config).oktaClient
 
-	exists, err := resourceUserExists(d, m)
-
-	if err != nil {
-		return err
-	}
-
-	// set Id to "" if the user can't be found to remove from state
-	if exists != true {
-		d.SetId("")
-		return nil
-	}
-
 	user, _, err := client.User.GetUser(d.Id())
 
 	if err != nil {
@@ -276,16 +263,10 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("status", user.Status)
 
-	// set all the attributes in state that were returned from user.Profile
-	for k, v := range *user.Profile {
-		if v != nil {
-			attribute := camelCaseToUnderscore(k)
+	err = setUserProfileAttributes(d, user)
 
-			log.Printf("[INFO] Setting %v to %v", attribute, v)
-			if err := d.Set(attribute, v); err != nil {
-				return fmt.Errorf("error setting %s for resource %s: %s", attribute, d.Id(), err)
-			}
-		}
+	if err != nil {
+		return err
 	}
 
 	// set all roles currently attached to user in state
@@ -388,241 +369,3 @@ func resourceUserExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	return true, nil
 }
 
-func populateUserProfile(d *schema.ResourceData) *okta.UserProfile {
-	profile := okta.UserProfile{}
-
-	profile["firstName"] = d.Get("first_name").(string)
-	profile["lastName"] = d.Get("last_name").(string)
-	profile["login"] = d.Get("login").(string)
-
-	if _, ok := d.GetOk("email"); ok {
-		profile["email"] = d.Get("email").(string)
-	} else {
-		profile["email"] = d.Get("login").(string)
-	}
-
-	if _, ok := d.GetOk("city"); ok {
-		profile["city"] = d.Get("city").(string)
-	}
-
-	if _, ok := d.GetOk("cost_center"); ok {
-		profile["costCenter"] = d.Get("cost_center").(string)
-	}
-
-	if _, ok := d.GetOk("country_code"); ok {
-		profile["countryCode"] = d.Get("country_code").(string)
-	}
-
-	if _, ok := d.GetOk("department"); ok {
-		profile["department"] = d.Get("department").(string)
-	}
-
-	if _, ok := d.GetOk("display_name"); ok {
-		profile["displayName"] = d.Get("display_name").(string)
-	}
-
-	if _, ok := d.GetOk("division"); ok {
-		profile["division"] = d.Get("division").(string)
-	}
-
-	if _, ok := d.GetOk("employee_number"); ok {
-		profile["employeeNumber"] = d.Get("employee_number").(string)
-	}
-
-	if _, ok := d.GetOk("honorific_prefix"); ok {
-		profile["honorificPrefix"] = d.Get("honorific_prefix").(string)
-	}
-
-	if _, ok := d.GetOk("honorific_suffix"); ok {
-		profile["honorificSuffix"] = d.Get("honorific_suffix").(string)
-	}
-
-	if _, ok := d.GetOk("locale"); ok {
-		profile["locale"] = d.Get("locale").(string)
-	}
-
-	if _, ok := d.GetOk("manager"); ok {
-		profile["manager"] = d.Get("manager").(string)
-	}
-
-	if _, ok := d.GetOk("manager_id"); ok {
-		profile["managerId"] = d.Get("manager_id").(string)
-	}
-
-	if _, ok := d.GetOk("middle_name"); ok {
-		profile["middleName"] = d.Get("middle_name").(string)
-	}
-
-	if _, ok := d.GetOk("mobile_phone"); ok {
-		profile["mobilePhone"] = d.Get("mobile_phone").(string)
-	}
-
-	if _, ok := d.GetOk("nick_name"); ok {
-		profile["nickName"] = d.Get("nick_name").(string)
-	}
-
-	if _, ok := d.GetOk("organization"); ok {
-		profile["organization"] = d.Get("organization").(string)
-	}
-
-	if _, ok := d.GetOk("postal_address"); ok {
-		profile["postalAddress"] = d.Get("postal_address").(string)
-	}
-
-	if _, ok := d.GetOk("preferred_language"); ok {
-		profile["preferredLanguage"] = d.Get("preferred_language").(string)
-	}
-
-	if _, ok := d.GetOk("primary_phone"); ok {
-		profile["primaryPhone"] = d.Get("primary_phone").(string)
-	}
-
-	if _, ok := d.GetOk("profile_url"); ok {
-		profile["profileUrl"] = d.Get("profile_url").(string)
-	}
-
-	if _, ok := d.GetOk("second_email"); ok {
-		profile["secondEmail"] = d.Get("second_email").(string)
-	}
-
-	if _, ok := d.GetOk("state"); ok {
-		profile["state"] = d.Get("state").(string)
-	}
-
-	if _, ok := d.GetOk("street_address"); ok {
-		profile["streetAddress"] = d.Get("street_address").(string)
-	}
-
-	if _, ok := d.GetOk("timezone"); ok {
-		profile["timezone"] = d.Get("timezone").(string)
-	}
-
-	if _, ok := d.GetOk("title"); ok {
-		profile["title"] = d.Get("title").(string)
-	}
-
-	if _, ok := d.GetOk("user_type"); ok {
-		profile["userType"] = d.Get("user_type").(string)
-	}
-
-	if _, ok := d.GetOk("zip_code"); ok {
-		profile["zipCode"] = d.Get("zip_code").(string)
-	}
-
-	return &profile
-}
-
-func assignAdminRolesToUser(u string, r []interface{}, c *okta.Client) error {
-	validRoles := []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN"}
-
-	for _, role := range r {
-		if contains(validRoles, role.(string)) {
-			roleStruct := okta.Role{Type: role.(string)}
-			_, _, err := c.User.AddRoleToUser(u, roleStruct)
-
-			if err != nil {
-				return fmt.Errorf("[ERROR] Error Assigning Admin Roles to User: %v", err)
-			}
-		} else {
-			return fmt.Errorf("[ERROR] %v is not a valid Okta role", role)
-		}
-	}
-
-	return nil
-}
-
-// need to remove from all current admin roles and reassign based on terraform configs when a change is detected
-func updateAdminRolesOnUser(u string, r []interface{}, c *okta.Client) error {
-	roles, _, err := c.User.ListAssignedRoles(u, nil)
-
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
-	}
-
-	for _, role := range roles {
-		_, err := c.User.RemoveRoleFromUser(u, role.Id)
-
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
-		}
-	}
-
-	err = assignAdminRolesToUser(u, r, c)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// regex lovingly lifted from: http://www.golangprograms.com/regular-expression-to-validate-email-address.html
-func matchEmailRegexp(val interface{}, key string) (warnings []string, errors []error) {
-	re := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-	if re.MatchString(val.(string)) == false {
-		errors = append(errors, fmt.Errorf("%s field not a valid email address", key))
-	}
-	return warnings, errors
-}
-
-// handle setting of user status based on what the current status is because okta
-// only allows transitions to certain statuses from other statuses - consult okta User API docs for more info
-// https://developer.okta.com/docs/api/resources/users#lifecycle-operations
-func updateUserStatus(u string, d string, c *okta.Client) error {
-	user, _, err := c.User.GetUser(u)
-
-	if err != nil {
-		return err
-	}
-
-	var statusErr error
-	switch d {
-	case "SUSPENDED":
-		_, statusErr = c.User.SuspendUser(u)
-	case "DEPROVISIONED":
-		_, statusErr = c.User.DeactivateUser(u)
-	case "ACTIVE":
-		if user.Status == "SUSPENDED" {
-			_, statusErr = c.User.UnsuspendUser(u)
-		} else {
-			_, _, statusErr = c.User.ActivateUser(u, nil)
-		}
-	}
-
-	if statusErr != nil {
-		return statusErr
-	}
-
-	err = waitForStatusTransition(u, c)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// need to wait for user.TransitioningToStatus field to be empty before allowing Terraform to continue
-// so the proper current status gets set in the state during the Read operation after a Status update
-func waitForStatusTransition(u string, c *okta.Client) error {
-	user, _, err := c.User.GetUser(u)
-
-	if err != nil {
-		return err
-	}
-
-	for {
-		if user.TransitioningToStatus == "" {
-			return nil
-		} else {
-			log.Printf("[INFO] Transitioning to status = %v; waiting for 5 more seconds...", user.TransitioningToStatus)
-			time.Sleep(5 * time.Second)
-
-			user, _, err = c.User.GetUser(u)
-
-			if err != nil {
-				return err
-			}
-		}
-	}
-}

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -28,18 +28,18 @@ func TestAccOktaUser_emailError(t *testing.T) {
 }
 
 func TestAccOktaUser_invalidCustomProfileAttribute(t *testing.T) {
-  rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    Steps: []resource.TestStep{
-      {
-        Config:      testOktaUserConfig_invalidCustomProfileAttribute(rName),
-        ExpectError: regexp.MustCompile("Api validation failed: newUser"),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testOktaUserConfig_invalidCustomProfileAttribute(rName),
+				ExpectError: regexp.MustCompile("Api validation failed: newUser"),
+			},
+		},
+	})
 }
 
 func TestAccOktaUser_updateDeprovisioned(t *testing.T) {
@@ -130,49 +130,49 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "zip_code", "11111"),
 				),
 			},
-      {
-        Config: testOktaUserConfig_removeFields(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-        ),
-      },
+			{
+				Config: testOktaUserConfig_removeFields(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+				),
+			},
 		},
 	})
 }
 
 func TestAccOktaUser_customProfileAttributes(t *testing.T) {
-  rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-  resourceName := "okta_user.test_acc_" + rName
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "okta_user.test_acc_" + rName
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testAccCheckUserDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testOktaUserConfig_customProfileAttributes(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes.testAcc"+rName, "testing-custom-attribute"),
-        ),
-      },
-      {
-        Config: testOktaUserConfig_removeCustomProfileAttributes(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOktaUserConfig_customProfileAttributes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes.testAcc"+rName, "testing-custom-attribute"),
+				),
+			},
+			{
+				Config: testOktaUserConfig_removeCustomProfileAttributes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckUserDestroy(s *terraform.State) error {
@@ -192,7 +192,7 @@ func testAccCheckUserDestroy(s *terraform.State) error {
 }
 
 func testOktaUserConfig(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
   admin_roles = ["APP_ADMIN", "USER_ADMIN"]
   first_name  = "TestAcc"
@@ -205,7 +205,7 @@ resource "okta_user" "test_acc_%s" {
 }
 
 func testOktaUserConfig_customProfileAttributes(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user_schemas" "test-%s" {
   subschema = "custom"
   index     = "testAcc%s"
@@ -243,7 +243,7 @@ resource "okta_user" "test_acc_%s" {
 }
 
 func testOktaUserConfig_emailError(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_%s" {
   firstname = "testAcc"
   lastname  = "%s"
@@ -255,7 +255,7 @@ resource "okta_user" "test_%s" {
 }
 
 func testOktaUserConfig_invalidCustomProfileAttribute(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
   admin_roles = ["APP_ADMIN", "USER_ADMIN"]
   first_name  = "TestAcc"
@@ -271,7 +271,7 @@ resource "okta_user" "test_acc_%s" {
 }
 
 func testOktaUserConfig_removeCustomProfileAttributes(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user_schemas" "test-%s" {
   subschema = "custom"
   index     = "testAcc%s"
@@ -290,7 +290,7 @@ resource "okta_user" "test_acc_%s" {
 }
 
 func testOktaUserConfig_removeFields(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
   admin_roles = ["APP_ADMIN", "USER_ADMIN"]
   first_name  = "TestAcc"
@@ -302,7 +302,7 @@ resource "okta_user" "test_acc_%s" {
 }
 
 func testOktaUserConfig_updated(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
   admin_roles        = ["ORG_ADMIN"]
   first_name         = "TestAcc"

--- a/okta/user.go
+++ b/okta/user.go
@@ -1,273 +1,273 @@
 package okta
 
 import (
-  "fmt"
-  "log"
-  "strings"
-  "time"
+	"fmt"
+	"log"
+	"strings"
+	"time"
 
-  "github.com/okta/okta-sdk-golang/okta"
-  "github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/okta/okta-sdk-golang/okta"
 )
 
 func assignAdminRolesToUser(u string, r []interface{}, c *okta.Client) error {
-  validRoles := []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN"}
+	validRoles := []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN"}
 
-  for _, role := range r {
-    if contains(validRoles, role.(string)) {
-      roleStruct := okta.Role{Type: role.(string)}
-      _, _, err := c.User.AddRoleToUser(u, roleStruct)
+	for _, role := range r {
+		if contains(validRoles, role.(string)) {
+			roleStruct := okta.Role{Type: role.(string)}
+			_, _, err := c.User.AddRoleToUser(u, roleStruct)
 
-      if err != nil {
-        return fmt.Errorf("[ERROR] Error Assigning Admin Roles to User: %v", err)
-      }
-    } else {
-      return fmt.Errorf("[ERROR] %v is not a valid Okta role", role)
-    }
-  }
+			if err != nil {
+				return fmt.Errorf("[ERROR] Error Assigning Admin Roles to User: %v", err)
+			}
+		} else {
+			return fmt.Errorf("[ERROR] %v is not a valid Okta role", role)
+		}
+	}
 
-  return nil
+	return nil
 }
 
 func populateUserProfile(d *schema.ResourceData) *okta.UserProfile {
-  profile := okta.UserProfile{}
+	profile := okta.UserProfile{}
 
-  if _, ok := d.GetOk("custom_profile_attributes"); ok {
-    for k, v := range d.Get("custom_profile_attributes").(map[string]interface{}) {
-      profile[k] = v
-    }
-  }
+	if _, ok := d.GetOk("custom_profile_attributes"); ok {
+		for k, v := range d.Get("custom_profile_attributes").(map[string]interface{}) {
+			profile[k] = v
+		}
+	}
 
-  profile["firstName"] = d.Get("first_name").(string)
-  profile["lastName"] = d.Get("last_name").(string)
-  profile["login"] = d.Get("login").(string)
-  profile["email"] = d.Get("email").(string)
+	profile["firstName"] = d.Get("first_name").(string)
+	profile["lastName"] = d.Get("last_name").(string)
+	profile["login"] = d.Get("login").(string)
+	profile["email"] = d.Get("email").(string)
 
-  if _, ok := d.GetOk("city"); ok {
-    profile["city"] = d.Get("city").(string)
-  }
+	if _, ok := d.GetOk("city"); ok {
+		profile["city"] = d.Get("city").(string)
+	}
 
-  if _, ok := d.GetOk("cost_center"); ok {
-    profile["costCenter"] = d.Get("cost_center").(string)
-  }
+	if _, ok := d.GetOk("cost_center"); ok {
+		profile["costCenter"] = d.Get("cost_center").(string)
+	}
 
-  if _, ok := d.GetOk("country_code"); ok {
-    profile["countryCode"] = d.Get("country_code").(string)
-  }
+	if _, ok := d.GetOk("country_code"); ok {
+		profile["countryCode"] = d.Get("country_code").(string)
+	}
 
-  if _, ok := d.GetOk("department"); ok {
-    profile["department"] = d.Get("department").(string)
-  }
+	if _, ok := d.GetOk("department"); ok {
+		profile["department"] = d.Get("department").(string)
+	}
 
-  if _, ok := d.GetOk("display_name"); ok {
-    profile["displayName"] = d.Get("display_name").(string)
-  }
+	if _, ok := d.GetOk("display_name"); ok {
+		profile["displayName"] = d.Get("display_name").(string)
+	}
 
-  if _, ok := d.GetOk("division"); ok {
-    profile["division"] = d.Get("division").(string)
-  }
+	if _, ok := d.GetOk("division"); ok {
+		profile["division"] = d.Get("division").(string)
+	}
 
-  if _, ok := d.GetOk("employee_number"); ok {
-    profile["employeeNumber"] = d.Get("employee_number").(string)
-  }
+	if _, ok := d.GetOk("employee_number"); ok {
+		profile["employeeNumber"] = d.Get("employee_number").(string)
+	}
 
-  if _, ok := d.GetOk("honorific_prefix"); ok {
-    profile["honorificPrefix"] = d.Get("honorific_prefix").(string)
-  }
+	if _, ok := d.GetOk("honorific_prefix"); ok {
+		profile["honorificPrefix"] = d.Get("honorific_prefix").(string)
+	}
 
-  if _, ok := d.GetOk("honorific_suffix"); ok {
-    profile["honorificSuffix"] = d.Get("honorific_suffix").(string)
-  }
+	if _, ok := d.GetOk("honorific_suffix"); ok {
+		profile["honorificSuffix"] = d.Get("honorific_suffix").(string)
+	}
 
-  if _, ok := d.GetOk("locale"); ok {
-    profile["locale"] = d.Get("locale").(string)
-  }
+	if _, ok := d.GetOk("locale"); ok {
+		profile["locale"] = d.Get("locale").(string)
+	}
 
-  if _, ok := d.GetOk("manager"); ok {
-    profile["manager"] = d.Get("manager").(string)
-  }
+	if _, ok := d.GetOk("manager"); ok {
+		profile["manager"] = d.Get("manager").(string)
+	}
 
-  if _, ok := d.GetOk("manager_id"); ok {
-    profile["managerId"] = d.Get("manager_id").(string)
-  }
+	if _, ok := d.GetOk("manager_id"); ok {
+		profile["managerId"] = d.Get("manager_id").(string)
+	}
 
-  if _, ok := d.GetOk("middle_name"); ok {
-    profile["middleName"] = d.Get("middle_name").(string)
-  }
+	if _, ok := d.GetOk("middle_name"); ok {
+		profile["middleName"] = d.Get("middle_name").(string)
+	}
 
-  if _, ok := d.GetOk("mobile_phone"); ok {
-    profile["mobilePhone"] = d.Get("mobile_phone").(string)
-  }
+	if _, ok := d.GetOk("mobile_phone"); ok {
+		profile["mobilePhone"] = d.Get("mobile_phone").(string)
+	}
 
-  if _, ok := d.GetOk("nick_name"); ok {
-    profile["nickName"] = d.Get("nick_name").(string)
-  }
+	if _, ok := d.GetOk("nick_name"); ok {
+		profile["nickName"] = d.Get("nick_name").(string)
+	}
 
-  if _, ok := d.GetOk("organization"); ok {
-    profile["organization"] = d.Get("organization").(string)
-  }
+	if _, ok := d.GetOk("organization"); ok {
+		profile["organization"] = d.Get("organization").(string)
+	}
 
-  // need to set profile.postalAddress to nil explicitly if not set because of a bug with this field
-  // have a support ticket open with okta about it
-  if _, ok := d.GetOk("postal_address"); ok {
-    profile["postalAddress"] = d.Get("postal_address").(string)
-  } else {
-    profile["postalAddress"] = nil
-  }
+	// need to set profile.postalAddress to nil explicitly if not set because of a bug with this field
+	// have a support ticket open with okta about it
+	if _, ok := d.GetOk("postal_address"); ok {
+		profile["postalAddress"] = d.Get("postal_address").(string)
+	} else {
+		profile["postalAddress"] = nil
+	}
 
-  if _, ok := d.GetOk("preferred_language"); ok {
-    profile["preferredLanguage"] = d.Get("preferred_language").(string)
-  }
+	if _, ok := d.GetOk("preferred_language"); ok {
+		profile["preferredLanguage"] = d.Get("preferred_language").(string)
+	}
 
-  if _, ok := d.GetOk("primary_phone"); ok {
-    profile["primaryPhone"] = d.Get("primary_phone").(string)
-  }
+	if _, ok := d.GetOk("primary_phone"); ok {
+		profile["primaryPhone"] = d.Get("primary_phone").(string)
+	}
 
-  if _, ok := d.GetOk("profile_url"); ok {
-    profile["profileUrl"] = d.Get("profile_url").(string)
-  }
+	if _, ok := d.GetOk("profile_url"); ok {
+		profile["profileUrl"] = d.Get("profile_url").(string)
+	}
 
-  if _, ok := d.GetOk("second_email"); ok {
-    profile["secondEmail"] = d.Get("second_email").(string)
-  }
+	if _, ok := d.GetOk("second_email"); ok {
+		profile["secondEmail"] = d.Get("second_email").(string)
+	}
 
-  if _, ok := d.GetOk("state"); ok {
-    profile["state"] = d.Get("state").(string)
-  }
+	if _, ok := d.GetOk("state"); ok {
+		profile["state"] = d.Get("state").(string)
+	}
 
-  if _, ok := d.GetOk("street_address"); ok {
-    profile["streetAddress"] = d.Get("street_address").(string)
-  }
+	if _, ok := d.GetOk("street_address"); ok {
+		profile["streetAddress"] = d.Get("street_address").(string)
+	}
 
-  if _, ok := d.GetOk("timezone"); ok {
-    profile["timezone"] = d.Get("timezone").(string)
-  }
+	if _, ok := d.GetOk("timezone"); ok {
+		profile["timezone"] = d.Get("timezone").(string)
+	}
 
-  if _, ok := d.GetOk("title"); ok {
-    profile["title"] = d.Get("title").(string)
-  }
+	if _, ok := d.GetOk("title"); ok {
+		profile["title"] = d.Get("title").(string)
+	}
 
-  if _, ok := d.GetOk("user_type"); ok {
-    profile["userType"] = d.Get("user_type").(string)
-  }
+	if _, ok := d.GetOk("user_type"); ok {
+		profile["userType"] = d.Get("user_type").(string)
+	}
 
-  if _, ok := d.GetOk("zip_code"); ok {
-    profile["zipCode"] = d.Get("zip_code").(string)
-  }
+	if _, ok := d.GetOk("zip_code"); ok {
+		profile["zipCode"] = d.Get("zip_code").(string)
+	}
 
-  return &profile
+	return &profile
 }
 
 func setUserProfileAttributes(d *schema.ResourceData, u *okta.User) error {
-  // any profile attributes that aren't explicitly outlined in the okta_user schema
-  // (ie. first_name) can be considered customAttributes
-  customAttributes := make(map[string]interface{})
+	// any profile attributes that aren't explicitly outlined in the okta_user schema
+	// (ie. first_name) can be considered customAttributes
+	customAttributes := make(map[string]interface{})
 
-  // set all the attributes in state that were returned from user.Profile
-  for k, v := range *u.Profile {
-    if v != nil {
-      attribute := camelCaseToUnderscore(k)
+	// set all the attributes in state that were returned from user.Profile
+	for k, v := range *u.Profile {
+		if v != nil {
+			attribute := camelCaseToUnderscore(k)
 
-      log.Printf("[INFO] Setting %v to %v", attribute, v)
-      if err := d.Set(attribute, v); err != nil {
-        if strings.Contains(err.Error(), "Invalid address to set") {
-          customAttributes[k] = v
-        } else {
-          return fmt.Errorf("error setting %s for resource %s: %s", attribute, d.Id(), err)
-        }
-      } 
-    }
-  }
+			log.Printf("[INFO] Setting %v to %v", attribute, v)
+			if err := d.Set(attribute, v); err != nil {
+				if strings.Contains(err.Error(), "Invalid address to set") {
+					customAttributes[k] = v
+				} else {
+					return fmt.Errorf("error setting %s for resource %s: %s", attribute, d.Id(), err)
+				}
+			}
+		}
+	}
 
-  // set the custom_profile_attributes values
-  return setNonPrimitives(d, map[string]interface{}{
-    "custom_profile_attributes": customAttributes,
-  })
+	// set the custom_profile_attributes values
+	return setNonPrimitives(d, map[string]interface{}{
+		"custom_profile_attributes": customAttributes,
+	})
 }
 
 // need to remove from all current admin roles and reassign based on terraform configs when a change is detected
 func updateAdminRolesOnUser(u string, r []interface{}, c *okta.Client) error {
-  roles, _, err := c.User.ListAssignedRoles(u, nil)
+	roles, _, err := c.User.ListAssignedRoles(u, nil)
 
-  if err != nil {
-    return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
-  }
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
+	}
 
-  for _, role := range roles {
-    _, err := c.User.RemoveRoleFromUser(u, role.Id)
+	for _, role := range roles {
+		_, err := c.User.RemoveRoleFromUser(u, role.Id)
 
-    if err != nil {
-      return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
-    }
-  }
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
+		}
+	}
 
-  err = assignAdminRolesToUser(u, r, c)
+	err = assignAdminRolesToUser(u, r, c)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 // handle setting of user status based on what the current status is because okta
 // only allows transitions to certain statuses from other statuses - consult okta User API docs for more info
 // https://developer.okta.com/docs/api/resources/users#lifecycle-operations
 func updateUserStatus(u string, d string, c *okta.Client) error {
-  user, _, err := c.User.GetUser(u)
+	user, _, err := c.User.GetUser(u)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  var statusErr error
-  switch d {
-  case "SUSPENDED":
-    _, statusErr = c.User.SuspendUser(u)
-  case "DEPROVISIONED":
-    _, statusErr = c.User.DeactivateUser(u)
-  case "ACTIVE":
-    if user.Status == "SUSPENDED" {
-      _, statusErr = c.User.UnsuspendUser(u)
-    } else {
-      _, _, statusErr = c.User.ActivateUser(u, nil)
-    }
-  }
+	var statusErr error
+	switch d {
+	case "SUSPENDED":
+		_, statusErr = c.User.SuspendUser(u)
+	case "DEPROVISIONED":
+		_, statusErr = c.User.DeactivateUser(u)
+	case "ACTIVE":
+		if user.Status == "SUSPENDED" {
+			_, statusErr = c.User.UnsuspendUser(u)
+		} else {
+			_, _, statusErr = c.User.ActivateUser(u, nil)
+		}
+	}
 
-  if statusErr != nil {
-    return statusErr
-  }
+	if statusErr != nil {
+		return statusErr
+	}
 
-  err = waitForStatusTransition(u, c)
+	err = waitForStatusTransition(u, c)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 // need to wait for user.TransitioningToStatus field to be empty before allowing Terraform to continue
 // so the proper current status gets set in the state during the Read operation after a Status update
 func waitForStatusTransition(u string, c *okta.Client) error {
-  user, _, err := c.User.GetUser(u)
+	user, _, err := c.User.GetUser(u)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  for {
-    if user.TransitioningToStatus == "" {
-      return nil
-    } else {
-      log.Printf("[INFO] Transitioning to status = %v; waiting for 5 more seconds...", user.TransitioningToStatus)
-      time.Sleep(5 * time.Second)
+	for {
+		if user.TransitioningToStatus == "" {
+			return nil
+		} else {
+			log.Printf("[INFO] Transitioning to status = %v; waiting for 5 more seconds...", user.TransitioningToStatus)
+			time.Sleep(5 * time.Second)
 
-      user, _, err = c.User.GetUser(u)
+			user, _, err = c.User.GetUser(u)
 
-      if err != nil {
-        return err
-      }
-    }
-  }
+			if err != nil {
+				return err
+			}
+		}
+	}
 }

--- a/okta/user.go
+++ b/okta/user.go
@@ -1,0 +1,273 @@
+package okta
+
+import (
+  "fmt"
+  "log"
+  "strings"
+  "time"
+
+  "github.com/okta/okta-sdk-golang/okta"
+  "github.com/hashicorp/terraform/helper/schema"
+)
+
+func assignAdminRolesToUser(u string, r []interface{}, c *okta.Client) error {
+  validRoles := []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN"}
+
+  for _, role := range r {
+    if contains(validRoles, role.(string)) {
+      roleStruct := okta.Role{Type: role.(string)}
+      _, _, err := c.User.AddRoleToUser(u, roleStruct)
+
+      if err != nil {
+        return fmt.Errorf("[ERROR] Error Assigning Admin Roles to User: %v", err)
+      }
+    } else {
+      return fmt.Errorf("[ERROR] %v is not a valid Okta role", role)
+    }
+  }
+
+  return nil
+}
+
+func populateUserProfile(d *schema.ResourceData) *okta.UserProfile {
+  profile := okta.UserProfile{}
+
+  if _, ok := d.GetOk("custom_profile_attributes"); ok {
+    for k, v := range d.Get("custom_profile_attributes").(map[string]interface{}) {
+      profile[k] = v
+    }
+  }
+
+  profile["firstName"] = d.Get("first_name").(string)
+  profile["lastName"] = d.Get("last_name").(string)
+  profile["login"] = d.Get("login").(string)
+  profile["email"] = d.Get("email").(string)
+
+  if _, ok := d.GetOk("city"); ok {
+    profile["city"] = d.Get("city").(string)
+  }
+
+  if _, ok := d.GetOk("cost_center"); ok {
+    profile["costCenter"] = d.Get("cost_center").(string)
+  }
+
+  if _, ok := d.GetOk("country_code"); ok {
+    profile["countryCode"] = d.Get("country_code").(string)
+  }
+
+  if _, ok := d.GetOk("department"); ok {
+    profile["department"] = d.Get("department").(string)
+  }
+
+  if _, ok := d.GetOk("display_name"); ok {
+    profile["displayName"] = d.Get("display_name").(string)
+  }
+
+  if _, ok := d.GetOk("division"); ok {
+    profile["division"] = d.Get("division").(string)
+  }
+
+  if _, ok := d.GetOk("employee_number"); ok {
+    profile["employeeNumber"] = d.Get("employee_number").(string)
+  }
+
+  if _, ok := d.GetOk("honorific_prefix"); ok {
+    profile["honorificPrefix"] = d.Get("honorific_prefix").(string)
+  }
+
+  if _, ok := d.GetOk("honorific_suffix"); ok {
+    profile["honorificSuffix"] = d.Get("honorific_suffix").(string)
+  }
+
+  if _, ok := d.GetOk("locale"); ok {
+    profile["locale"] = d.Get("locale").(string)
+  }
+
+  if _, ok := d.GetOk("manager"); ok {
+    profile["manager"] = d.Get("manager").(string)
+  }
+
+  if _, ok := d.GetOk("manager_id"); ok {
+    profile["managerId"] = d.Get("manager_id").(string)
+  }
+
+  if _, ok := d.GetOk("middle_name"); ok {
+    profile["middleName"] = d.Get("middle_name").(string)
+  }
+
+  if _, ok := d.GetOk("mobile_phone"); ok {
+    profile["mobilePhone"] = d.Get("mobile_phone").(string)
+  }
+
+  if _, ok := d.GetOk("nick_name"); ok {
+    profile["nickName"] = d.Get("nick_name").(string)
+  }
+
+  if _, ok := d.GetOk("organization"); ok {
+    profile["organization"] = d.Get("organization").(string)
+  }
+
+  // need to set profile.postalAddress to nil explicitly if not set because of a bug with this field
+  // have a support ticket open with okta about it
+  if _, ok := d.GetOk("postal_address"); ok {
+    profile["postalAddress"] = d.Get("postal_address").(string)
+  } else {
+    profile["postalAddress"] = nil
+  }
+
+  if _, ok := d.GetOk("preferred_language"); ok {
+    profile["preferredLanguage"] = d.Get("preferred_language").(string)
+  }
+
+  if _, ok := d.GetOk("primary_phone"); ok {
+    profile["primaryPhone"] = d.Get("primary_phone").(string)
+  }
+
+  if _, ok := d.GetOk("profile_url"); ok {
+    profile["profileUrl"] = d.Get("profile_url").(string)
+  }
+
+  if _, ok := d.GetOk("second_email"); ok {
+    profile["secondEmail"] = d.Get("second_email").(string)
+  }
+
+  if _, ok := d.GetOk("state"); ok {
+    profile["state"] = d.Get("state").(string)
+  }
+
+  if _, ok := d.GetOk("street_address"); ok {
+    profile["streetAddress"] = d.Get("street_address").(string)
+  }
+
+  if _, ok := d.GetOk("timezone"); ok {
+    profile["timezone"] = d.Get("timezone").(string)
+  }
+
+  if _, ok := d.GetOk("title"); ok {
+    profile["title"] = d.Get("title").(string)
+  }
+
+  if _, ok := d.GetOk("user_type"); ok {
+    profile["userType"] = d.Get("user_type").(string)
+  }
+
+  if _, ok := d.GetOk("zip_code"); ok {
+    profile["zipCode"] = d.Get("zip_code").(string)
+  }
+
+  return &profile
+}
+
+func setUserProfileAttributes(d *schema.ResourceData, u *okta.User) error {
+  // any profile attributes that aren't explicitly outlined in the okta_user schema
+  // (ie. first_name) can be considered customAttributes
+  customAttributes := make(map[string]interface{})
+
+  // set all the attributes in state that were returned from user.Profile
+  for k, v := range *u.Profile {
+    if v != nil {
+      attribute := camelCaseToUnderscore(k)
+
+      log.Printf("[INFO] Setting %v to %v", attribute, v)
+      if err := d.Set(attribute, v); err != nil {
+        if strings.Contains(err.Error(), "Invalid address to set") {
+          customAttributes[k] = v
+        } else {
+          return fmt.Errorf("error setting %s for resource %s: %s", attribute, d.Id(), err)
+        }
+      } 
+    }
+  }
+
+  // set the custom_profile_attributes values
+  return setNonPrimitives(d, map[string]interface{}{
+    "custom_profile_attributes": customAttributes,
+  })
+}
+
+// need to remove from all current admin roles and reassign based on terraform configs when a change is detected
+func updateAdminRolesOnUser(u string, r []interface{}, c *okta.Client) error {
+  roles, _, err := c.User.ListAssignedRoles(u, nil)
+
+  if err != nil {
+    return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
+  }
+
+  for _, role := range roles {
+    _, err := c.User.RemoveRoleFromUser(u, role.Id)
+
+    if err != nil {
+      return fmt.Errorf("[ERROR] Error Updating Admin Roles On User: %v", err)
+    }
+  }
+
+  err = assignAdminRolesToUser(u, r, c)
+
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+// handle setting of user status based on what the current status is because okta
+// only allows transitions to certain statuses from other statuses - consult okta User API docs for more info
+// https://developer.okta.com/docs/api/resources/users#lifecycle-operations
+func updateUserStatus(u string, d string, c *okta.Client) error {
+  user, _, err := c.User.GetUser(u)
+
+  if err != nil {
+    return err
+  }
+
+  var statusErr error
+  switch d {
+  case "SUSPENDED":
+    _, statusErr = c.User.SuspendUser(u)
+  case "DEPROVISIONED":
+    _, statusErr = c.User.DeactivateUser(u)
+  case "ACTIVE":
+    if user.Status == "SUSPENDED" {
+      _, statusErr = c.User.UnsuspendUser(u)
+    } else {
+      _, _, statusErr = c.User.ActivateUser(u, nil)
+    }
+  }
+
+  if statusErr != nil {
+    return statusErr
+  }
+
+  err = waitForStatusTransition(u, c)
+
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+// need to wait for user.TransitioningToStatus field to be empty before allowing Terraform to continue
+// so the proper current status gets set in the state during the Read operation after a Status update
+func waitForStatusTransition(u string, c *okta.Client) error {
+  user, _, err := c.User.GetUser(u)
+
+  if err != nil {
+    return err
+  }
+
+  for {
+    if user.TransitioningToStatus == "" {
+      return nil
+    } else {
+      log.Printf("[INFO] Transitioning to status = %v; waiting for 5 more seconds...", user.TransitioningToStatus)
+      time.Sleep(5 * time.Second)
+
+      user, _, err = c.User.GetUser(u)
+
+      if err != nil {
+        return err
+      }
+    }
+  }
+}

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -170,11 +170,11 @@ func is404(client *articulateOkta.Client) bool {
 
 // regex lovingly lifted from: http://www.golangprograms.com/regular-expression-to-validate-email-address.html
 func matchEmailRegexp(val interface{}, key string) (warnings []string, errors []error) {
-  re := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-  if re.MatchString(val.(string)) == false {
-    errors = append(errors, fmt.Errorf("%s field not a valid email address", key))
-  }
-  return warnings, errors
+	re := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	if re.MatchString(val.(string)) == false {
+		errors = append(errors, fmt.Errorf("%s field not a valid email address", key))
+	}
+	return warnings, errors
 }
 
 // The best practices states that aggregate types should have error handling (think non-primitive). This will not attempt to set nil values.


### PR DESCRIPTION
utilizing a `custom_profile_attributes` map that will allow folks to control the setting of custom attributes to their users that is outside of the standard attributes provided by Okta (like firstName, lastName, company, etc.)  This does require that the attribute be set beforehand to the user profile schema as per their [user API documentation](https://developer.okta.com/docs/api/resources/users#profile-object).