### PR TITLE
Stop doing validation in CustomizeDiff

### DIFF
--- a/okta/policy.go
+++ b/okta/policy.go
@@ -174,3 +174,7 @@ func resourcePolicyExists(d *schema.ResourceData, m interface{}) (b bool, e erro
 
 	return true, nil
 }
+
+func ensureNotDefaultPolicy(d *schema.ResourceData) error {
+	return ensureNotDefault(d, "Policy")
+}

--- a/okta/policy_rule.go
+++ b/okta/policy_rule.go
@@ -238,3 +238,7 @@ func createPolicyRuleImporter() *schema.ResourceImporter {
 		},
 	}
 }
+
+func ensureNotDefaultRule(d *schema.ResourceData) error {
+	return ensureNotDefault(d, "Rule")
+}

--- a/okta/resource_oauth_app_test.go
+++ b/okta/resource_oauth_app_test.go
@@ -150,7 +150,6 @@ func TestAccOktaOAuthApplicationBadGrantTypes(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				PlanOnly:    true,
 				Config:      config,
 				ExpectError: regexp.MustCompile(`failed conditional validation for field "grant_types" of type "service", it can contain client_credentials, received implicit`),
 			},

--- a/okta/resource_password_policy_rule.go
+++ b/okta/resource_password_policy_rule.go
@@ -20,9 +20,6 @@ func resourcePasswordPolicyRule() *schema.Resource {
 
 		CustomizeDiff: func(d *schema.ResourceDiff, v interface{}) error {
 			// user cannot edit a default policy rule
-			if d.Get("name").(string) == "Default Rule" {
-				return fmt.Errorf("You cannot edit a default Policy Rule")
-			}
 
 			return nil
 		},
@@ -54,6 +51,10 @@ func resourcePasswordPolicyRule() *schema.Resource {
 }
 
 func resourcePasswordPolicyRuleCreate(d *schema.ResourceData, m interface{}) error {
+	if err := ensureNotDefaultRule(d); err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Creating Policy Rule %v", d.Get("name").(string))
 	client := getClientFromMetadata(m)
 	template := buildPasswordPolicyRule(d, client)
@@ -89,6 +90,10 @@ func resourcePasswordPolicyRuleRead(d *schema.ResourceData, m interface{}) error
 }
 
 func resourcePasswordPolicyRuleUpdate(d *schema.ResourceData, m interface{}) error {
+	if err := ensureNotDefaultRule(d); err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Update Policy Rule %v", d.Get("name").(string))
 	client := getClientFromMetadata(m)
 	template := buildPasswordPolicyRule(d, client)
@@ -107,6 +112,10 @@ func resourcePasswordPolicyRuleUpdate(d *schema.ResourceData, m interface{}) err
 }
 
 func resourcePasswordPolicyRuleDelete(d *schema.ResourceData, m interface{}) error {
+	if err := ensureNotDefaultRule(d); err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Delete Policy Rule %v", d.Get("name").(string))
 	client := getClientFromMetadata(m)
 

--- a/okta/resource_sign_on_policy_rule.go
+++ b/okta/resource_sign_on_policy_rule.go
@@ -18,15 +18,6 @@ func resourceSignOnPolicyRule() *schema.Resource {
 		Delete:   resourceSignOnPolicyRuleDelete,
 		Importer: createPolicyRuleImporter(),
 
-		CustomizeDiff: func(d *schema.ResourceDiff, v interface{}) error {
-			// user cannot edit a default policy rule
-			if d.Get("name").(string) == "Default Rule" {
-				return fmt.Errorf("You cannot edit a default Policy Rule")
-			}
-
-			return nil
-		},
-
 		Schema: buildRuleSchema(map[string]*schema.Schema{
 			"authtype": {
 				Type:         schema.TypeString,
@@ -88,6 +79,10 @@ func resourceSignOnPolicyRule() *schema.Resource {
 }
 
 func resourceSignOnPolicyRuleCreate(d *schema.ResourceData, m interface{}) error {
+	if err := ensureNotDefaultRule(d); err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Creating Policy Rule %v", d.Get("name").(string))
 	template, err := buildSignOnPolicyRule(d, m)
 	if err != nil {
@@ -140,6 +135,10 @@ func resourceSignOnPolicyRuleRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSignOnPolicyRuleUpdate(d *schema.ResourceData, m interface{}) error {
+	if err := ensureNotDefaultRule(d); err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Update Policy Rule %v", d.Get("name").(string))
 	template, err := buildSignOnPolicyRule(d, m)
 	if err != nil {
@@ -160,6 +159,10 @@ func resourceSignOnPolicyRuleUpdate(d *schema.ResourceData, m interface{}) error
 }
 
 func resourceSignOnPolicyRuleDelete(d *schema.ResourceData, m interface{}) error {
+	if err := ensureNotDefaultRule(d); err != nil {
+		return err
+	}
+
 	log.Printf("[INFO] Delete Policy Rule %v", d.Get("name").(string))
 	client := m.(*Config).articulateOktaClient
 

--- a/okta/resource_sign_on_policy_rule_test.go
+++ b/okta/resource_sign_on_policy_rule_test.go
@@ -17,13 +17,13 @@ func TestAccOktaPolicyRuleDefaultErrors(t *testing.T) {
 	config := testOktaPolicyRuleSignOnDefaultErrors(acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: createRuleCheckDestroy(signOnPolicyRule),
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("You cannot edit a default Policy Rule"),
-				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Default Rule is immutable"),
 			},
 		},
 	})

--- a/okta/resource_sign_on_policy_test.go
+++ b/okta/resource_sign_on_policy_test.go
@@ -18,13 +18,13 @@ func TestAccOktaPoliciesDefaultErrors(t *testing.T) {
 	config := testOktaPolicySignOnDefaultErrors(ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: createPolicyCheckDestroy(signOnPolicy),
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("You cannot edit a default Policy"),
-				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Default Policy is immutable"),
 			},
 		},
 	})

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -195,3 +195,13 @@ func conditionalValidator(field string, typeValue string, require []string, vali
 
 	return nil
 }
+
+func ensureNotDefault(d *schema.ResourceData, t string) error {
+	thing := fmt.Sprintf("Default %s", t)
+
+	if d.Get("name").(string) == thing {
+		return fmt.Errorf("%s is immutable", thing)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is not the proper pattern. Looking at other providers the proper
way to do this is in the CRUD functions.

There are still more of this to refactor but I thought I would atleast do the few that I worked with earlier.