### PR TITLE
add group_memberships field to the okta_user resource

### DIFF
--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -239,13 +239,17 @@ func resourceUserCreate(d *schema.ResourceData, m interface{}) error {
 	// role assigning can only happen after the user is created so order matters here
 	roles := convertInterfaceToStringArrNullable(d.Get("admin_roles"))
 	if roles != nil {
-		if err = assignAdminRolesToUser(user.Id, roles, client); err != nil { return err }
+		if err = assignAdminRolesToUser(user.Id, roles, client); err != nil {
+			return err
+		}
 	}
 
 	// group assigning can only happen after the user is created as well
 	groups := convertInterfaceToStringArrNullable(d.Get("group_memberships"))
 	if groups != nil {
-		if err = assignGroupsToUser(user.Id, groups, client); err != nil { return err }
+		if err = assignGroupsToUser(user.Id, groups, client); err != nil {
+			return err
+		}
 	}
 
 	// status changing can only happen after user is created as well
@@ -316,12 +320,16 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 
 		if d.HasChange("admin_roles") {
 			roles := convertInterfaceToStringArr(d.Get("admin_roles"))
-			if err := updateAdminRolesOnUser(d.Id(), roles, client); err != nil { return err }
+			if err := updateAdminRolesOnUser(d.Id(), roles, client); err != nil {
+				return err
+			}
 		}
 
 		if d.HasChange("group_memberships") {
 			groups := convertInterfaceToStringArr(d.Get("group_memberships"))
-			if err := updateGroupsOnUser(d.Id(), groups, client); err != nil { return err }
+			if err := updateGroupsOnUser(d.Id(), groups, client); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -246,12 +246,9 @@ func resourceUserCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// group assigning can only happen after the user is created as well
-	if len(d.Get("group_memberships").([]interface{})) > 0 {
-		err = assignGroupsToUser(user.Id, d.Get("group_memberships").([]interface{}), client)
-
-		if err != nil {
-			return err
-		}
+	groups := convertInterfaceToStringArrNullable(d.Get("group_memberships"))
+	if groups != nil {
+		if err = assignGroupsToUser(user.Id, groups, client); err != nil { return err }
 	}
 
 	// status changing can only happen after user is created as well
@@ -329,11 +326,8 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		if d.HasChange("group_memberships") {
-			err := updateGroupsOnUser(d.Id(), d.Get("group_memberships").([]interface{}), client)
-
-			if err != nil {
-				return err
-			}
+			groups := convertInterfaceToStringArr(d.Get("group_memberships"))
+			if err := updateGroupsOnUser(d.Id(), groups, client); err != nil { return err }
 		}
 	}
 

--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -316,6 +316,10 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 
 		_, _, err := client.User.UpdateUser(d.Id(), userBody)
 
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error Updating User in Okta: %v", err)
+		}
+
 		if d.HasChange("admin_roles") {
 			err := updateAdminRolesOnUser(d.Id(), d.Get("admin_roles").([]interface{}), client)
 
@@ -330,14 +334,6 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 			if err != nil {
 				return err
 			}
-		}
-
-		if len(d.Get("group_memberships").([]interface{})) > 0 {
-			return nil
-		}
-
-		if err != nil {
-			return fmt.Errorf("[ERROR] Error Updating User in Okta: %v", err)
 		}
 	}
 

--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -237,12 +237,9 @@ func resourceUserCreate(d *schema.ResourceData, m interface{}) error {
 	d.SetId(user.Id)
 
 	// role assigning can only happen after the user is created so order matters here
-	if len(d.Get("admin_roles").([]interface{})) > 0 {
-		err = assignAdminRolesToUser(user.Id, d.Get("admin_roles").([]interface{}), client)
-
-		if err != nil {
-			return err
-		}
+	roles := convertInterfaceToStringArrNullable(d.Get("admin_roles"))
+	if roles != nil {
+		if err = assignAdminRolesToUser(user.Id, roles, client); err != nil { return err }
 	}
 
 	// group assigning can only happen after the user is created as well
@@ -318,11 +315,8 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		if d.HasChange("admin_roles") {
-			err := updateAdminRolesOnUser(d.Id(), d.Get("admin_roles").([]interface{}), client)
-
-			if err != nil {
-				return err
-			}
+			roles := convertInterfaceToStringArr(d.Get("admin_roles"))
+			if err := updateAdminRolesOnUser(d.Id(), roles, client); err != nil { return err }
 		}
 
 		if d.HasChange("group_memberships") {

--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -278,9 +278,13 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("status", user.Status)
 
-	if err = setUserProfileAttributes(d, user); err != nil { return err }
+	if err = setUserProfileAttributes(d, user); err != nil {
+		return err
+	}
 
-	if err = setAdminRoles(d, client); err != nil { return err }
+	if err = setAdminRoles(d, client); err != nil {
+		return err
+	}
 
 	return setGroups(d, client)
 }

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -12,35 +12,35 @@ import (
 )
 
 func TestAccOktaUser_customProfileAttributes(t *testing.T) {
-  rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-  resourceName := "okta_user.test_acc_" + rName
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "okta_user.test_acc_" + rName
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testAccCheckUserDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testOktaUserConfig_customProfileAttributes(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes.testAcc"+rName, "testing-custom-attribute"),
-        ),
-      },
-      {
-        Config: testOktaUserConfig_removeCustomProfileAttributes(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOktaUserConfig_customProfileAttributes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "custom_profile_attributes.testAcc"+rName, "testing-custom-attribute"),
+				),
+			},
+			{
+				Config: testOktaUserConfig_removeCustomProfileAttributes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccOktaUser_emailError(t *testing.T) {
@@ -60,48 +60,48 @@ func TestAccOktaUser_emailError(t *testing.T) {
 }
 
 func TestAccOktaUser_groupMembership(t *testing.T) {
-  rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-  resourceName := "okta_user.test_acc_" + rName
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "okta_user.test_acc_" + rName
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testAccCheckUserDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testOktaUserConfig_groupAssign(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
-        ),
-      },
-      {
-        Config: testOktaUserConfig_groupUnassign(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
-        ),
-      },
-      {
-        Config: testOktaUserConfig_groupAssign(rName),
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOktaUserConfig_groupAssign(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
+				),
+			},
+			{
+				Config: testOktaUserConfig_groupUnassign(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
+				),
+			},
+			{
+				Config: testOktaUserConfig_groupAssign(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccOktaUser_invalidCustomProfileAttribute(t *testing.T) {
@@ -134,10 +134,10 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "2"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.0", "APP_ADMIN"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.1", "USER_ADMIN"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.0", "APP_ADMIN"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.1", "USER_ADMIN"),
 				),
 			},
 			{
@@ -147,8 +147,8 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
 					resource.TestCheckResourceAttr(resourceName, "email", "test1-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "1"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.0", "ORG_ADMIN"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.0", "ORG_ADMIN"),
 					resource.TestCheckResourceAttr(resourceName, "city", "New York"),
 					resource.TestCheckResourceAttr(resourceName, "cost_center", "10"),
 					resource.TestCheckResourceAttr(resourceName, "country_code", "US"),
@@ -185,7 +185,7 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "0"),
 				),
 			},
 		},
@@ -193,38 +193,38 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 }
 
 func TestAccOktaUser_updateDeprovisioned(t *testing.T) {
-  rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testAccCheckUserDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testOktaUserConfig_deprovisioned(rName),
-      },
-      {
-        Config:      testOktaUserConfig_updateDeprovisioned(rName),
-        ExpectError: regexp.MustCompile("Cannot update a DEPROVISIONED user"),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOktaUserConfig_deprovisioned(rName),
+			},
+			{
+				Config:      testOktaUserConfig_updateDeprovisioned(rName),
+				ExpectError: regexp.MustCompile("Cannot update a DEPROVISIONED user"),
+			},
+		},
+	})
 }
 
 func TestAccOktaUser_validRole(t *testing.T) {
-  rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testAccCheckUserDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config:      testOktaUserConfig_validRole(rName),
-        ExpectError: regexp.MustCompile("GROUP_ADMIN is not a valid Okta role"),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testOktaUserConfig_validRole(rName),
+				ExpectError: regexp.MustCompile("GROUP_ADMIN is not a valid Okta role"),
+			},
+		},
+	})
 }
 
 func testAccCheckUserDestroy(s *terraform.State) error {
@@ -307,7 +307,7 @@ resource "okta_user" "test_%s" {
 }
 
 func testOktaUserConfig_groupAssign(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
   first_name  = "TestAcc"
   last_name   = "%s"
@@ -320,7 +320,7 @@ resource "okta_user" "test_acc_%s" {
 }
 
 func testOktaUserConfig_groupUnassign(r string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
   first_name  = "TestAcc"
   last_name   = "%s"

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -59,50 +59,48 @@ func TestAccOktaUser_emailError(t *testing.T) {
 	})
 }
 
-func TestAccOktaUser_groupMembership(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resourceName := "okta_user.test_acc_" + rName
+// func TestAccOktaUser_groupMembership(t *testing.T) {
+// 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+// 	resourceName := "okta_user.test_acc_" + rName
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckUserDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testOktaUserConfig_groupAssign(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
-				),
-			},
-			{
-				Config: testOktaUserConfig_groupUnassign(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
-				),
-			},
-			{
-				Config: testOktaUserConfig_groupAssign(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckUserDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testOktaUserConfig_groupAssign(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+// 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+// 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+// 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+// 					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+// 				),
+// 			},
+// 			{
+// 				Config: testOktaUserConfig_groupUnassign(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+// 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+// 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+// 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+// 					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
+// 				),
+// 			},
+// 			{
+// 				Config: testOktaUserConfig_groupAssign(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+// 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+// 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+// 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+// 					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
 func TestAccOktaUser_invalidCustomProfileAttribute(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -306,29 +304,39 @@ resource "okta_user" "test_%s" {
 `, r, r, r)
 }
 
-func testOktaUserConfig_groupAssign(r string) string {
-	return fmt.Sprintf(`
-resource "okta_user" "test_acc_%s" {
-  first_name  = "TestAcc"
-  last_name   = "%s"
-  login       = "test-acc-%s@testing.com"
-  email       = "test-acc-%s@testing.com"
+// func testOktaUserConfig_groupAssign(r string) string {
+// 	return fmt.Sprintf(`
+// resource "okta_group" "test_acc_%s" {
+//   name        = "TestACC-%s"
+//   description = "An acceptance test created group"
+// }
 
-  group_memberships = ["00gelojjimp9rOokb0h7"]
-}
-`, r, r, r, r)
-}
+// resource "okta_user" "test_acc_%s" {
+//   first_name  = "TestAcc"
+//   last_name   = "%s"
+//   login       = "test-acc-%s@testing.com"
+//   email       = "test-acc-%s@testing.com"
 
-func testOktaUserConfig_groupUnassign(r string) string {
-	return fmt.Sprintf(`
-resource "okta_user" "test_acc_%s" {
-  first_name  = "TestAcc"
-  last_name   = "%s"
-  login       = "test-acc-%s@testing.com"
-  email       = "test-acc-%s@testing.com"
-}
-`, r, r, r, r)
-}
+//   group_memberships = ["${okta_group.test_acc_%s.id}"]
+// }
+// `, r, r, r, r, r, r, r)
+// }
+
+// func testOktaUserConfig_groupUnassign(r string) string {
+// 	return fmt.Sprintf(`
+// resource "okta_group" "test_acc_%s" {
+//   name        = "TestACC-%s"
+//   description = "An acceptance test created group"
+// }
+
+// resource "okta_user" "test_acc_%s" {
+//   first_name  = "TestAcc"
+//   last_name   = "%s"
+//   login       = "test-acc-%s@testing.com"
+//   email       = "test-acc-%s@testing.com"
+// }
+// `, r, r, r, r, r, r)
+// }
 
 func testOktaUserConfig_invalidCustomProfileAttribute(r string) string {
 	return fmt.Sprintf(`

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -89,6 +89,17 @@ func TestAccOktaUser_groupMembership(t *testing.T) {
           resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
         ),
       },
+      {
+        Config: testOktaUserConfig_groupAssign(rName),
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+          resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+          resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+          resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+          resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "group_memberships.0", "00gelojjimp9rOokb0h7"),
+        ),
+      },
     },
   })
 }

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -59,48 +59,48 @@ func TestAccOktaUser_emailError(t *testing.T) {
 	})
 }
 
-// func TestAccOktaUser_groupMembership(t *testing.T) {
-// 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-// 	resourceName := "okta_user.test_acc_" + rName
+func TestAccOktaUser_groupMembership(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resourceName := "okta_user.test_acc_" + rName
 
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:     func() { testAccPreCheck(t) },
-// 		Providers:    testAccProviders,
-// 		CheckDestroy: testAccCheckUserDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testOktaUserConfig_groupAssign(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-// 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-// 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-// 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-// 					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
-// 				),
-// 			},
-// 			{
-// 				Config: testOktaUserConfig_groupUnassign(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-// 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-// 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-// 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-// 					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
-// 				),
-// 			},
-// 			{
-// 				Config: testOktaUserConfig_groupAssign(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
-// 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
-// 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
-// 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-// 					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOktaUserConfig_groupAssign(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+				),
+			},
+			{
+				Config: testOktaUserConfig_groupUnassign(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "0"),
+				),
+			},
+			{
+				Config: testOktaUserConfig_groupAssign(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
+					resource.TestCheckResourceAttr(resourceName, "group_memberships.#", "1"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccOktaUser_invalidCustomProfileAttribute(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -304,39 +304,39 @@ resource "okta_user" "test_%s" {
 `, r, r, r)
 }
 
-// func testOktaUserConfig_groupAssign(r string) string {
-// 	return fmt.Sprintf(`
-// resource "okta_group" "test_acc_%s" {
-//   name        = "TestACC-%s"
-//   description = "An acceptance test created group"
-// }
+func testOktaUserConfig_groupAssign(r string) string {
+	return fmt.Sprintf(`
+resource "okta_group" "test_acc_%s" {
+  name        = "TestACC-%s"
+  description = "An acceptance test created group"
+}
 
-// resource "okta_user" "test_acc_%s" {
-//   first_name  = "TestAcc"
-//   last_name   = "%s"
-//   login       = "test-acc-%s@testing.com"
-//   email       = "test-acc-%s@testing.com"
+resource "okta_user" "test_acc_%s" {
+  first_name  = "TestAcc"
+  last_name   = "%s"
+  login       = "test-acc-%s@testing.com"
+  email       = "test-acc-%s@testing.com"
 
-//   group_memberships = ["${okta_group.test_acc_%s.id}"]
-// }
-// `, r, r, r, r, r, r, r)
-// }
+  group_memberships = ["${okta_group.test_acc_%s.id}"]
+}
+`, r, r, r, r, r, r, r)
+}
 
-// func testOktaUserConfig_groupUnassign(r string) string {
-// 	return fmt.Sprintf(`
-// resource "okta_group" "test_acc_%s" {
-//   name        = "TestACC-%s"
-//   description = "An acceptance test created group"
-// }
+func testOktaUserConfig_groupUnassign(r string) string {
+	return fmt.Sprintf(`
+resource "okta_group" "test_acc_%s" {
+  name        = "TestACC-%s"
+  description = "An acceptance test created group"
+}
 
-// resource "okta_user" "test_acc_%s" {
-//   first_name  = "TestAcc"
-//   last_name   = "%s"
-//   login       = "test-acc-%s@testing.com"
-//   email       = "test-acc-%s@testing.com"
-// }
-// `, r, r, r, r, r, r)
-// }
+resource "okta_user" "test_acc_%s" {
+  first_name  = "TestAcc"
+  last_name   = "%s"
+  login       = "test-acc-%s@testing.com"
+  email       = "test-acc-%s@testing.com"
+}
+`, r, r, r, r, r, r)
+}
 
 func testOktaUserConfig_invalidCustomProfileAttribute(r string) string {
 	return fmt.Sprintf(`

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -174,9 +174,7 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "last_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "login", "test-acc-"+rName+"@testing.com"),
 					resource.TestCheckResourceAttr(resourceName, "email", "test-acc-"+rName+"@testing.com"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "2"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.0", "APP_ADMIN"),
-          resource.TestCheckResourceAttr(resourceName, "admin_roles.1", "USER_ADMIN"),
+          resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "0"),
 				),
 			},
 		},
@@ -359,7 +357,6 @@ resource "okta_user" "test_acc_%s" {
 func testOktaUserConfig_removeFields(r string) string {
 	return fmt.Sprintf(`
 resource "okta_user" "test_acc_%s" {
-  admin_roles = ["APP_ADMIN", "USER_ADMIN"]
   first_name  = "TestAcc"
   last_name   = "%s"
   login       = "test-acc-%s@testing.com"

--- a/okta/user.go
+++ b/okta/user.go
@@ -29,6 +29,18 @@ func assignAdminRolesToUser(u string, r []interface{}, c *okta.Client) error {
 	return nil
 }
 
+func assignGroupsToUser(u string, g []interface{}, c *okta.Client) error {
+	for _, group := range g {
+		_, err := c.Group.AddUserToGroup(group.(string), u)
+
+		if err != nil {
+			return fmt.Errorf("[ERROR] Error Assigning Group to User: %v", err)
+		}
+	}
+
+	return nil
+}
+
 func populateUserProfile(d *schema.ResourceData) *okta.UserProfile {
 	profile := okta.UserProfile{}
 
@@ -158,6 +170,48 @@ func populateUserProfile(d *schema.ResourceData) *okta.UserProfile {
 	return &profile
 }
 
+func setAdminRoles(d *schema.ResourceData, c *okta.Client) error {
+	// set all roles currently attached to user in state
+	roles, _, err := c.User.ListAssignedRoles(d.Id(), nil)
+
+	if err != nil {
+		return err
+	}
+
+	roleTypes := make([]string, 0)
+	for _, role := range roles {
+		roleTypes = append(roleTypes, role.Type)
+	}
+
+	// set the custom_profile_attributes values
+	return setNonPrimitives(d, map[string]interface{}{
+		"admin_roles": roleTypes,
+	})
+}
+
+func setGroups(d *schema.ResourceData, c *okta.Client) error {
+	// set all groups currently attached to user in state
+	groups, _, err := c.User.ListUserGroups(d.Id(), nil)
+
+	groupIds := make([]string, 0)
+
+	// ignore saving the Everyone group into state so we don't end up with perpetual diffs
+	for _, group := range groups {
+		if group.Profile.Name != "Everyone" {
+			groupIds = append(groupIds, group.Id)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// set the custom_profile_attributes values
+	return setNonPrimitives(d, map[string]interface{}{
+		"group_memberships": groupIds,
+	})
+}
+
 func setUserProfileAttributes(d *schema.ResourceData, u *okta.User) error {
 	// any profile attributes that aren't explicitly outlined in the okta_user schema
 	// (ie. first_name) can be considered customAttributes
@@ -206,6 +260,29 @@ func updateAdminRolesOnUser(u string, r []interface{}, c *okta.Client) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// need to remove from all current groups and reassign based on terraform configs when a change is detected
+func updateGroupsOnUser(u string, g []interface{}, c *okta.Client) error {
+	groups, _, err := c.User.ListUserGroups(u, nil)
+
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error Updating Groups On User: %v", err)
+	}
+
+	for _, group := range groups {
+		if group.Profile.Name != "Everyone" {
+			_, err := c.Group.RemoveGroupUser(group.Id, u)
+
+			if err != nil {
+				return fmt.Errorf("[ERROR] Error Updating Groups On User: %v", err)
+			}
+		}
+	}
+
+	if err = assignGroupsToUser(u, g, c); err != nil { return err }
 
 	return nil
 }

--- a/okta/user.go
+++ b/okta/user.go
@@ -29,9 +29,9 @@ func assignAdminRolesToUser(u string, r []interface{}, c *okta.Client) error {
 	return nil
 }
 
-func assignGroupsToUser(u string, g []interface{}, c *okta.Client) error {
+func assignGroupsToUser(u string, g []string, c *okta.Client) error {
 	for _, group := range g {
-		_, err := c.Group.AddUserToGroup(group.(string), u)
+		_, err := c.Group.AddUserToGroup(group, u)
 
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error Assigning Group to User: %v", err)
@@ -265,7 +265,7 @@ func updateAdminRolesOnUser(u string, r []interface{}, c *okta.Client) error {
 }
 
 // need to remove from all current groups and reassign based on terraform configs when a change is detected
-func updateGroupsOnUser(u string, g []interface{}, c *okta.Client) error {
+func updateGroupsOnUser(u string, g []string, c *okta.Client) error {
 	groups, _, err := c.User.ListUserGroups(u, nil)
 
 	if err != nil {

--- a/okta/user.go
+++ b/okta/user.go
@@ -10,12 +10,12 @@ import (
 	"github.com/okta/okta-sdk-golang/okta"
 )
 
-func assignAdminRolesToUser(u string, r []interface{}, c *okta.Client) error {
+func assignAdminRolesToUser(u string, r []string, c *okta.Client) error {
 	validRoles := []string{"SUPER_ADMIN", "ORG_ADMIN", "API_ACCESS_MANAGEMENT_ADMIN", "APP_ADMIN", "USER_ADMIN", "MOBILE_ADMIN", "READ_ONLY_ADMIN", "HELP_DESK_ADMIN"}
 
 	for _, role := range r {
-		if contains(validRoles, role.(string)) {
-			roleStruct := okta.Role{Type: role.(string)}
+		if contains(validRoles, role) {
+			roleStruct := okta.Role{Type: role}
 			_, _, err := c.User.AddRoleToUser(u, roleStruct)
 
 			if err != nil {
@@ -240,7 +240,7 @@ func setUserProfileAttributes(d *schema.ResourceData, u *okta.User) error {
 }
 
 // need to remove from all current admin roles and reassign based on terraform configs when a change is detected
-func updateAdminRolesOnUser(u string, r []interface{}, c *okta.Client) error {
+func updateAdminRolesOnUser(u string, r []string, c *okta.Client) error {
 	roles, _, err := c.User.ListAssignedRoles(u, nil)
 
 	if err != nil {

--- a/okta/user.go
+++ b/okta/user.go
@@ -282,7 +282,9 @@ func updateGroupsOnUser(u string, g []interface{}, c *okta.Client) error {
 		}
 	}
 
-	if err = assignGroupsToUser(u, g, c); err != nil { return err }
+	if err = assignGroupsToUser(u, g, c); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
adding the ability to assign/remove [group memberships to an Okta user](https://developer.okta.com/docs/api/resources/groups#add-user-to-group) via the `okta_user` resource using the `group_memberships` list attribute.