### PR TITLE
Fix SAML App import bug

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-VERSION=v2.4.0
+VERSION=v2.5.0
 
 SWEEP?=global
 TEST?=$$(go list ./... |grep -v 'vendor')

--- a/examples/okta_saml_app/import.tf
+++ b/examples/okta_saml_app/import.tf
@@ -1,0 +1,9 @@
+resource "okta_saml_app" "testAcc_%[1]d" {
+  preconfigured_app = "pagerduty"
+  label             = "testAcc_%[1]d"
+  app_settings_json = <<JSON
+{
+  "subdomain": "articulate"
+}
+JSON
+}

--- a/okta/resource_saml_app.go
+++ b/okta/resource_saml_app.go
@@ -46,8 +46,10 @@ func resourceSamlApp() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Name of preexisting SAML application. For instance 'slack'",
-				// A new app type requires it be deleted and recreated
-				ForceNew: true,
+				ForceNew:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return new == ""
+				},
 			},
 			"key": {
 				Type:        schema.TypeMap,
@@ -352,6 +354,7 @@ func resourceSamlAppRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("user_name_template", app.Credentials.UserNameTemplate.Template)
 	d.Set("user_name_template_type", app.Credentials.UserNameTemplate.Type)
 	d.Set("user_name_template_suffix", app.Credentials.UserNameTemplate.Suffix)
+	d.Set("preconfigured_app", app.Name)
 	err = setAppSettings(d, app.Settings.App)
 	if err != nil {
 		return err

--- a/okta/resource_three_field_app_test.go
+++ b/okta/resource_three_field_app_test.go
@@ -42,7 +42,7 @@ func TestAccOktaThreeFieldApplication(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "button_selector", "btn1"),
 					resource.TestCheckResourceAttr(resourceName, "username_selector", "user1"),
 					resource.TestCheckResourceAttr(resourceName, "password_selector", "pass1"),
-					resource.TestCheckResourceAttr(resourceName, "url", "http://examplechanged.com"),
+					resource.TestCheckResourceAttr(resourceName, "url", "http://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "extra_field_selector", "mfa"),
 					resource.TestCheckResourceAttr(resourceName, "extra_field_value", "mfa"),
 				),
@@ -60,8 +60,8 @@ resource "%s" "%s" {
   button_selector		= "btn"
   username_selector		= "user"
   password_selector		= "pass"
-  url					= "http://example.com"
-  extra_field_selector  = "third"
+  url			        = "http://example.com"
+  extra_field_selector          = "third"
   extra_field_value		= "third"
 }
 `, threeFieldApp, name, name)
@@ -73,12 +73,12 @@ func buildTestThreeFieldConfigUpdated(rInt int) string {
 	return fmt.Sprintf(`
 resource "%s" "%s" {
   label       			= "%s"
-  status 	  			= "INACTIVE"
+  status 	  		= "INACTIVE"
   button_selector		= "btn1"
   username_selector		= "user1"
   password_selector		= "pass1"
-  url					= "http://examplechanged.com"
-  extra_field_selector  = "mfa"
+  url			        = "http://example.com"
+  extra_field_selector 	        = "mfa"
   extra_field_value		= "mfa"
 }
 `, threeFieldApp, name, name)


### PR DESCRIPTION
preconfigured_app was not be read into state, fix this and add import test. A change in the preconfigured app requires recreation otherwise Okta just ignores it, and suppress diff for computed name when preconfigured_app is not set in config. 