### PR TITLE
Ignore 404 when removing group and user associations

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-VERSION=v2.5.0
+VERSION=v2.6.0
 
 SWEEP?=global
 TEST?=$$(go list ./... |grep -v 'vendor')

--- a/okta/app.go
+++ b/okta/app.go
@@ -216,8 +216,7 @@ func handleAppGroups(id string, d *schema.ResourceData, client *okta.Client) []f
 
 		if !contains {
 			asyncActionList = append(asyncActionList, func() error {
-				_, err := client.Application.DeleteApplicationGroupAssignment(id, group.Id)
-				return err
+				return suppressErrorOn404(client.Application.DeleteApplicationGroupAssignment(id, group.Id))
 			})
 		}
 	}
@@ -295,9 +294,7 @@ func handleAppUsers(id string, d *schema.ResourceData, client *okta.Client) []fu
 
 			if !contains {
 				asyncActionList = append(asyncActionList, func() error {
-					_, err := client.Application.DeleteApplicationUser(id, user.Id)
-
-					return err
+					return suppressErrorOn404(client.Application.DeleteApplicationUser(id, user.Id))
 				})
 			}
 		}

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -3,6 +3,7 @@ package okta
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"unicode"
@@ -190,6 +191,16 @@ func ensureNotDefault(d *schema.ResourceData, t string) error {
 	}
 
 	return nil
+}
+
+// Useful shortcut for suppressing errors from Okta's SDK when a resource does not exist. Usually used during deletion
+// of nested resources.
+func suppressErrorOn404(resp *okta.Response, err error) error {
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+
+	return err
 }
 
 func getApiToken(m interface{}) string {


### PR DESCRIPTION
An app we use was manually manipulated, and due to this, when a group was removed in the config, the 404 caused the provider to error out. In retrospect this is where having an actual resource for each of these associations would be nice because of the Exists function, though the config would explode in size so leaving it as is! 