### PR TITLE
Allow user to be deprovisioned

### DIFF
--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -361,7 +362,7 @@ func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if status == "DEPROVISIONED" && (userChange || roleChange || groupChange) {
-		return fmt.Errorf("[ERROR] Only the status of a DEPROVISIONED user can be updated, we detected other change.")
+		return errors.New("[ERROR] Only the status of a DEPROVISIONED user can be updated, we detected other change")
 	}
 
 	if userChange {

--- a/okta/resource_user.go
+++ b/okta/resource_user.go
@@ -11,6 +11,44 @@ import (
 	"github.com/okta/okta-sdk-golang/okta/query"
 )
 
+// All profile properties here so we can do a diff against the config to see if any have changed before making the
+// request or before erring due to an update on a user that is DEPROVISIONED. Since we have core user props coupled
+// with group/user membership a few change requests go out in the Update function.
+var profileKeys = []string{
+	"city",
+	"cost_center",
+	"country_code",
+	"custom_profile_attributes",
+	"department",
+	"display_name",
+	"division",
+	"email",
+	"employee_number",
+	"first_name",
+	"honorific_prefix",
+	"honorific_suffix",
+	"last_name",
+	"locale",
+	"login",
+	"manager",
+	"manager_id",
+	"middle_name",
+	"mobile_phone",
+	"nick_name",
+	"organization",
+	"postal_address",
+	"preferred_language",
+	"primary_phone",
+	"profile_url",
+	"second_email",
+	"state",
+	"street_address",
+	"timezone",
+	"title",
+	"user_type",
+	"zip_code",
+}
+
 func resourceUser() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceUserCreate,
@@ -297,51 +335,75 @@ func resourceUserRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceUserUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Update User %v", d.Get("login").(string))
+	status := d.Get("status").(string)
 
-	if d.Get("status").(string) == "STAGED" {
+	if status == "STAGED" {
 		return fmt.Errorf("[ERROR] Okta will not allow a user to be updated to STAGED. Can set to STAGED on user creation only.")
 	}
 
-	client := m.(*Config).oktaClient
+	client := getOktaClientFromMetadata(m)
+	// There are a few requests here so just making sure the state gets updated per successful downstream change
+	d.Partial(true)
+
+	roleChange := d.HasChange("admin_roles")
+	groupChange := d.HasChange("group_memberships")
+	statusChange := d.HasChange("status")
+	userChange := hasProfileChange(d)
 
 	// run the update status func first so a user that was previously deprovisioned
 	// can be updated further if it's status changed in it's terraform configs
-	if d.HasChange("status") {
-		err := updateUserStatus(d.Id(), d.Get("status").(string), client)
-
+	if statusChange {
+		err := updateUserStatus(d.Id(), status, client)
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error Updating Status for User: %v", err)
 		}
+		d.SetPartial("status")
 	}
 
-	if d.Get("status") == "DEPROVISIONED" {
-		return fmt.Errorf("[ERROR] Cannot update a DEPROVISIONED user")
-	} else {
+	if status == "DEPROVISIONED" && (userChange || roleChange || groupChange) {
+		return fmt.Errorf("[ERROR] Only the status of a DEPROVISIONED user can be updated, we detected other change.")
+	}
+
+	if userChange {
 		profile := populateUserProfile(d)
 		userBody := okta.User{Profile: profile}
 
 		_, _, err := client.User.UpdateUser(d.Id(), userBody)
-
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error Updating User in Okta: %v", err)
 		}
-
-		if d.HasChange("admin_roles") {
-			roles := convertInterfaceToStringArr(d.Get("admin_roles"))
-			if err := updateAdminRolesOnUser(d.Id(), roles, client); err != nil {
-				return err
-			}
-		}
-
-		if d.HasChange("group_memberships") {
-			groups := convertInterfaceToStringArr(d.Get("group_memberships"))
-			if err := updateGroupsOnUser(d.Id(), groups, client); err != nil {
-				return err
-			}
-		}
 	}
 
+	if roleChange {
+		roles := convertInterfaceToStringArr(d.Get("admin_roles"))
+		if err := updateAdminRolesOnUser(d.Id(), roles, client); err != nil {
+			return err
+		}
+		d.SetPartial("admin_roles")
+	}
+
+	if groupChange {
+		groups := convertInterfaceToStringArr(d.Get("group_memberships"))
+		if err := updateGroupsOnUser(d.Id(), groups, client); err != nil {
+			return err
+		}
+		d.SetPartial("group_membership")
+	}
+	d.Partial(false)
+
 	return resourceUserRead(d, m)
+}
+
+// Checks whether any profile keys have changed, this is necessary since the profile is not nested. Also, necessary
+// to give a sensible user readable error when they attempt to update a DEPROVISIONED user. Previously
+// this error always occurred when you set a user's status to DEPROVISIONED.
+func hasProfileChange(d *schema.ResourceData) bool {
+	for _, k := range profileKeys {
+		if d.HasChange(k) {
+			return true
+		}
+	}
+	return false
 }
 
 func resourceUserDelete(d *schema.ResourceData, m interface{}) error {

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -233,7 +233,7 @@ func TestAccOktaUser_updateDeprovisioned(t *testing.T) {
 			},
 			{
 				Config:      testOktaUserConfig_updateDeprovisioned(strconv.Itoa(ri)),
-				ExpectError: regexp.MustCompile("[ERROR] Only the status of a DEPROVISIONED user can be updated, we detected other change."),
+				ExpectError: regexp.MustCompile(".*Only the status of a DEPROVISIONED user can be updated, we detected other change"),
 			},
 		},
 	})

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -188,6 +188,36 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 	})
 }
 
+func TestAccOktaUser_statusDeprovisioned(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(oktaUser)
+	statusChanged := mgr.GetFixtures("okta_user_deprovisioned.tf", ri, t)
+	config := mgr.GetFixtures("okta_user_staged.tf", ri, t)
+	resourceName := buildResourceFQN(oktaUser, ri)
+	email := fmt.Sprintf("test-acc-%d@testing.com", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				Config: statusChanged,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Smith"),
+					resource.TestCheckResourceAttr(resourceName, "login", email),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "status", "DEPROVISIONED"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOktaUser_updateDeprovisioned(t *testing.T) {
 	ri := acctest.RandInt()
 	mgr := newFixtureManager(oktaUser)
@@ -203,7 +233,7 @@ func TestAccOktaUser_updateDeprovisioned(t *testing.T) {
 			},
 			{
 				Config:      testOktaUserConfig_updateDeprovisioned(strconv.Itoa(ri)),
-				ExpectError: regexp.MustCompile("Cannot update a DEPROVISIONED user"),
+				ExpectError: regexp.MustCompile("[ERROR] Only the status of a DEPROVISIONED user can be updated, we detected other change."),
 			},
 		},
 	})
@@ -243,41 +273,41 @@ func testAccCheckUserDestroy(s *terraform.State) error {
 
 func testOktaUserConfig_invalidCustomProfileAttribute(r string) string {
 	return fmt.Sprintf(`
-resource okta_user "testAcc_%s" {
+resource okta_user "testAcc_%[1]s" {
   admin_roles = ["APP_ADMIN", "USER_ADMIN"]
   first_name  = "TestAcc"
-  last_name   = "%s"
-  login       = "test-acc-%s@testing.com"
-  email       = "test-acc-%s@testing.com"
+  last_name   = "%[1]s"
+  login       = "test-acc-%[1]s@testing.com"
+  email       = "test-acc-%[1]s@testing.com"
 
   custom_profile_attributes {
     notValid = "this-isnt-valid"
   }
 }
-`, r, r, r, r)
+`, r)
 }
 
 func testOktaUserConfig_updateDeprovisioned(r string) string {
 	return fmt.Sprintf(`
-resource okta_user "testAcc_%s" {
+resource okta_user "testAcc_%[1]s" {
   admin_roles = ["APP_ADMIN", "USER_ADMIN"]
   first_name  = "TestAcc"
-  last_name   = "%s"
-  login       = "test-acc-%s@testing.com"
+  last_name   = "%[1]s"
+  login       = "test-acc-%[1]s@testing.com"
   status      = "DEPROVISIONED"
   email       = "hello@testing.com"
 }
-`, r, r, r)
+`, r)
 }
 
 func testOktaUserConfig_validRole(r string) string {
 	return fmt.Sprintf(`
-resource okta_user "testAcc_%s" {
+resource okta_user "testAcc_%[1]s" {
   admin_roles = ["APP_ADMIN", "USER_ADMIN", "GROUP_ADMIN"]
   first_name  = "TestAcc"
-  last_name   = "%s"
-  login       = "test-acc-%s@testing.com"
-  email       = "test-acc-%s@testing.com"
+  last_name   = "Smith"
+  login       = "test-acc-%[1]s@testing.com"
+  email       = "test-acc-%[1]s@testing.com"
 }
-`, r, r, r, r)
+`, r)
 }


### PR DESCRIPTION
Fixes #104 

Allow user to be deprovisioned without an error and only make a profile update request if there is a change.