### PR TITLE
RequestExecutor does not take query params, manually build the URL

### DIFF
--- a/okta/app.go
+++ b/okta/app.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -21,6 +22,7 @@ type (
 	}
 
 	appFilters struct {
+		ApiFilter         string
 		ID                string
 		Label             string
 		LabelPrefix       string
@@ -432,21 +434,26 @@ func setAppSettings(d *schema.ResourceData, settings *okta.ApplicationSettingsAp
 
 func listApps(m interface{}, filters *appFilters) ([]*appID, error) {
 	result := &searchResults{Apps: []*appID{}}
-	return result.Apps, collectApps(getSupplementFromMetadata(m).requestExecutor, filters, result, &query.Params{})
+	qp := &query.Params{Limit: 200, Filter: filters.ApiFilter}
+	return result.Apps, collectApps(getSupplementFromMetadata(m).requestExecutor, filters, result, qp)
 }
 
 // Recursively list apps until no next links are returned
 func collectApps(reqExe *okta.RequestExecutor, filters *appFilters, results *searchResults, qp *query.Params) error {
-	req, err := reqExe.NewRequest("GET", "/api/v1/apps", qp)
+	req, err := reqExe.NewRequest("GET", fmt.Sprintf("/api/v1/apps?%s", qp.String()), nil)
 	if err != nil {
 		return err
 	}
 	var appList []*appID
 	res, err := reqExe.Do(req, &appList)
+	if err != nil {
+		return err
+	}
 
 	results.Apps = append(results.Apps, filterApp(appList, filters)...)
 
-	if after := getAfterParam(res); after != "" && filters.shouldShortCircuit(results.Apps) {
+	if after := getAfterParam(res); after != "" && !filters.shouldShortCircuit(results.Apps) {
+		fmt.Printf("%s %+v --\n", after, filters)
 		qp.After = after
 		return collectApps(reqExe, filters, results, qp)
 	}

--- a/okta/app.go
+++ b/okta/app.go
@@ -453,7 +453,6 @@ func collectApps(reqExe *okta.RequestExecutor, filters *appFilters, results *sea
 	results.Apps = append(results.Apps, filterApp(appList, filters)...)
 
 	if after := getAfterParam(res); after != "" && !filters.shouldShortCircuit(results.Apps) {
-		fmt.Printf("%s %+v --\n", after, filters)
 		qp.After = after
 		return collectApps(reqExe, filters, results, qp)
 	}

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -251,7 +251,11 @@ func ensureNotDefault(d *schema.ResourceData, t string) error {
 
 // Grabs after link from link headers if it exists
 func getAfterParam(res *okta.Response) string {
-	linkList := link.Parse(res.Header.Get("link"))
+	if res == nil {
+		return ""
+	}
+
+	linkList := link.ParseHeader(res.Header)
 	for _, l := range linkList {
 		if l.Rel == "next" {
 			parsedURL, err := url.Parse(l.URI)


### PR DESCRIPTION
I found out that Header.Get does not return the raw header, it previously parses the headers into a slice of strings, .Get gives you the first one but I realized there was a utility function for this anyways!

Added the ability to search active apps only to speed things up, as well as increase the limit param to avoid hitting rate limits constantly.