### PR TITLE
Switch to using cleanhttp

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -474,7 +474,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f660c3db66967e1f9217ccb3e802b709484c77f7b435910055fe9548f5fcf292"
+  digest = "1:b581e5ade5db1a49d900d057e02f3f0745ccf48d315da7ec4dd5f4fea4ed3b9d"
   name = "github.com/okta/okta-sdk-golang"
   packages = [
     "okta",
@@ -482,7 +482,7 @@
     "okta/query",
   ]
   pruneopts = "UT"
-  revision = "9aebf1c68684bf005a5ae99de20104c7155fad75"
+  revision = "fefd5d396088cee4925fa5725542fd3040063420"
   source = "https://github.com/articulate/okta-sdk-golang.git"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -673,6 +673,7 @@
   input-imports = [
     "github.com/articulate/oktasdk-go/okta",
     "github.com/dghubble/sling",
+    "github.com/hashicorp/go-cleanhttp",
     "github.com/hashicorp/terraform/helper/acctest",
     "github.com/hashicorp/terraform/helper/resource",
     "github.com/hashicorp/terraform/helper/schema",

--- a/okta/resource_saml_app.go
+++ b/okta/resource_saml_app.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/dghubble/sling"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/okta/okta-sdk-golang/okta"
@@ -558,7 +559,7 @@ func getMetadata(d *schema.ResourceData, m interface{}, keyId string) (string, e
 		return "", err
 	}
 
-	httpClient := http.Client{}
+	httpClient := cleanhttp.DefaultClient()
 	res, err := httpClient.Do(req)
 	defer res.Body.Close()
 	if err != nil {


### PR DESCRIPTION
This includes initialising proxy settings, etc.

cleanhttp is already pulled in as a dependency so I figured it's reasonable to use it instead. This is the only occurrence of directly creating an `http.Client` instance that I could see in the code so I think it's the only piece left to fix #130 