### PR TITLE
Metadata is returned as bytes now

### DIFF
--- a/okta/resource_saml_app.go
+++ b/okta/resource_saml_app.go
@@ -385,7 +385,7 @@ func resourceSamlAppRead(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return err
 		}
-		d.Set("metadata", keyMetadata)
+		d.Set("metadata", string(keyMetadata))
 
 		metadataRoot := &root{}
 		err = xml.Unmarshal(keyMetadata, metadataRoot)


### PR DESCRIPTION
This works without conversion for the XML parsing but Terraform will
ignore it as an attribute value so cast it to a string.

Fixes #131 