### PR TITLE
Fix Okta Policy user/group include/exclude

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,8 @@ Anything that lies underneath a resource directory is config we use as fixtures 
 * [okta_idp_saml](./okta_idp_saml) Supports the management of Okta SAML Identity Providers.
 * [okta_policy_signon](./okta_policy_signon) Supports the management of sign on policies.
 * [okta_policy_rule_signon](./okta_policy_rule_signon) Supports the management of sign on policy rules.
+* [okta_policy_mfa](./okta_policy_mfa) Supports the management of MFA policies.
+* [okta_policy_password](./okta_policy_password) Supports the management of password policies.
 * [okta_app_oauth_redirect_uri](./okta_app_oauth_redirect_uri) Supports decentralizing redirect uri config. Due to Okta's API not allowing this field to be null, you must set a redirect uri in your app, and ignore changes to this attribute. We follow TF best practices and detect config drift. The best case scenario is Okta makes this field nullable and we can not detect config drift when this attr is not present.
 
 ## Deprecated Resources

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,7 +30,9 @@ Anything that lies underneath a resource directory is config we use as fixtures 
 * [okta_inline_hook](./okta_inline_hook) Supports the management of Okta Inline Hooks EA feature.
 * [okta_idp](./okta_idp) Supports the management of Okta OIDC Identity Providers.
 * [okta_idp_social](./okta_idp_social) Supports the management of Okta Social Identity Providers. Such as Google, Facebook, Microsoft, and LinkedIn.
-* [okta_idp_saml](./okta_idp) Supports the management of Okta SAML Identity Providers.
+* [okta_idp_saml](./okta_idp_saml) Supports the management of Okta SAML Identity Providers.
+* [okta_policy_signon](./okta_policy_signon) Supports the management of sign on policies.
+* [okta_policy_rule_signon](./okta_policy_rule_signon) Supports the management of sign on policy rules.
 * [okta_app_oauth_redirect_uri](./okta_app_oauth_redirect_uri) Supports decentralizing redirect uri config. Due to Okta's API not allowing this field to be null, you must set a redirect uri in your app, and ignore changes to this attribute. We follow TF best practices and detect config drift. The best case scenario is Okta makes this field nullable and we can not detect config drift when this attr is not present.
 
 ## Deprecated Resources

--- a/examples/okta_policy_mfa/README.md
+++ b/examples/okta_policy_mfa/README.md
@@ -1,0 +1,5 @@
+# okta_policy_mfa
+
+This resource represents an Okta MFA Policy. For more information see the [API docs](https://developer.okta.com/docs/api/resources/policy)
+
+* Example of a simple mfa policy [can be found here](./basic.tf)

--- a/examples/okta_policy_mfa/basic.tf
+++ b/examples/okta_policy_mfa/basic.tf
@@ -1,0 +1,15 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_mfa test {
+  name        = "testAcc_replace_with_uuid"
+  status      = "ACTIVE"
+  description = "Terraform Acceptance Test MFA Policy"
+
+  google_otp = {
+    enroll = "REQUIRED"
+  }
+
+  groups_included = ["${data.okta_group.all.id}"]
+}

--- a/examples/okta_policy_mfa/basic_updated.tf
+++ b/examples/okta_policy_mfa/basic_updated.tf
@@ -1,0 +1,26 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_mfa test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "INACTIVE"
+  description     = "Terraform Acceptance Test MFA Policy Updated"
+  groups_included = ["${data.okta_group.all.id}"]
+
+  fido_u2f = {
+    enroll = "OPTIONAL"
+  }
+
+  google_otp = {
+    enroll = "OPTIONAL"
+  }
+
+  okta_otp = {
+    enroll = "OPTIONAL"
+  }
+
+  okta_sms = {
+    enroll = "OPTIONAL"
+  }
+}

--- a/examples/okta_policy_password/README.md
+++ b/examples/okta_policy_password/README.md
@@ -1,0 +1,5 @@
+# okta_policy_password
+
+This resource represents an Okta Password Policy. For more information see the [API docs](https://developer.okta.com/docs/api/resources/policy)
+
+* Example of a simple password policy [can be found here](./basic.tf)

--- a/examples/okta_policy_password/basic.tf
+++ b/examples/okta_policy_password/basic.tf
@@ -1,0 +1,10 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_password test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test Password Policy"
+  groups_included = ["${data.okta_group.all.id}"]
+}

--- a/examples/okta_policy_password/basic_updated.tf
+++ b/examples/okta_policy_password/basic_updated.tf
@@ -1,0 +1,29 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_password test {
+  name                           = "testAcc_replace_with_uuid"
+  status                         = "INACTIVE"
+  description                    = "Terraform Acceptance Test Password Policy Updated"
+  password_min_length            = 12
+  password_min_lowercase         = 0
+  password_min_uppercase         = 0
+  password_min_number            = 0
+  password_min_symbol            = 1
+  password_exclude_username      = false
+  password_exclude_first_name    = true
+  password_exclude_last_name     = true
+  password_max_age_days          = 60
+  password_expire_warn_days      = 15
+  password_min_age_minutes       = 60
+  password_history_count         = 5
+  password_max_lockout_attempts  = 3
+  password_auto_unlock_minutes   = 2
+  password_show_lockout_failures = true
+  question_min_length            = 10
+  recovery_email_token           = 20160
+  sms_recovery                   = "ACTIVE"
+
+  groups_included = ["${data.okta_group.all.id}"]
+}

--- a/examples/okta_policy_rule_signon/README.md
+++ b/examples/okta_policy_rule_signon/README.md
@@ -1,0 +1,6 @@
+
+# okta_policy_rule_signon
+
+This resource represents an Okta Sign On Policy Rule. For more information see the [API docs](https://developer.okta.com/docs/api/resources/policy#rules)
+
+* Example of a simple sign on policy rule [can be found here](./basic.tf)

--- a/examples/okta_policy_rule_signon/basic.tf
+++ b/examples/okta_policy_rule_signon/basic.tf
@@ -1,0 +1,16 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_signon test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = ["${data.okta_group.all.id}"]
+}
+
+resource okta_policy_rule_signon test {
+  policyid = "${okta_policy_signon.test.id}"
+  name     = "testAcc_replace_with_uuid"
+  status   = "ACTIVE"
+}

--- a/examples/okta_policy_rule_signon/basic_updated.tf
+++ b/examples/okta_policy_rule_signon/basic_updated.tf
@@ -1,0 +1,28 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_user test {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  email      = "testAcc_replace_with_uuid@gmail.com"
+  login      = "testAcc_replace_with_uuid@gmail.com"
+}
+
+resource okta_policy_signon test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = ["${data.okta_group.all.id}"]
+}
+
+resource okta_policy_rule_signon test {
+  policyid           = "${okta_policy_signon.test.id}"
+  name               = "testAcc_replace_with_uuid"
+  status             = "INACTIVE"
+  access             = "DENY"
+  session_idle       = 240
+  session_lifetime   = 240
+  session_persistent = false
+  users_excluded     = ["${okta_user.test.id}"]
+}

--- a/examples/okta_policy_signon/README.md
+++ b/examples/okta_policy_signon/README.md
@@ -1,0 +1,5 @@
+# okta_policy_signon
+
+This resource represents an Okta Sign On Policy. For more information see the [API docs](https://developer.okta.com/docs/api/resources/policy)
+
+* Example of a simple sign on policy [can be found here](./basic.tf)

--- a/examples/okta_policy_signon/basic.tf
+++ b/examples/okta_policy_signon/basic.tf
@@ -1,0 +1,24 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_user test {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  email      = "testAcc_replace_with_uuid@gmail.com"
+  login      = "testAcc_replace_with_uuid@gmail.com"
+}
+
+resource okta_policy_signon test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = ["${data.okta_group.all.id}"]
+}
+
+resource okta_policy_rule_signon test {
+  policyid       = "${okta_policy_signon.test.id}"
+  name           = "testAcc_replace_with_uuid"
+  status         = "ACTIVE"
+  users_excluded = ["${okta_user.test.id}"]
+}

--- a/examples/okta_policy_signon/basic_inactive.tf
+++ b/examples/okta_policy_signon/basic_inactive.tf
@@ -1,0 +1,10 @@
+resource okta_group test {
+  name = "testAcc_replace_with_uuid"
+}
+
+resource okta_policy_signon test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "INACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy Updated"
+  groups_included = ["${okta_group.test.id}"]
+}

--- a/examples/okta_policy_signon/basic_renamed.tf
+++ b/examples/okta_policy_signon/basic_renamed.tf
@@ -1,0 +1,10 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_signon test {
+  name            = "testAccUpdated_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = ["${data.okta_group.all.id}"]
+}

--- a/okta/resource_policy_mfa_test.go
+++ b/okta/resource_policy_mfa_test.go
@@ -14,9 +14,10 @@ func deleteMfaPolicies(client *testClient) error {
 
 func TestAccOktaMfaPolicy(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testOktaMfaPolicy(ri)
-	updatedConfig := testOktaMfaPolicyUpdated(ri)
-	resourceName := buildResourceFQN(policyMfa, ri)
+	mgr := newFixtureManager(policyMfa)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
+	resourceName := fmt.Sprintf("%s.test", policyMfa)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -48,46 +49,4 @@ func TestAccOktaMfaPolicy(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testOktaMfaPolicy(rInt int) string {
-	name := buildResourceName(rInt)
-
-	return fmt.Sprintf(`
-resource "%s" "%s" {
-  name        		= "%s"
-  status      		= "ACTIVE"
-  description 		= "Terraform Acceptance Test MFA Policy"
-  google_otp = {
-	  enroll = "REQUIRED"
-  }
-}
-`, policyMfa, name, name)
-}
-
-func testOktaMfaPolicyUpdated(rInt int) string {
-	name := buildResourceName(rInt)
-
-	return fmt.Sprintf(`
-data "okta_everyone_group" "everyone-%d" {}
-
-resource "%s" "%s" {
-	name        = "%s"
-	status      = "INACTIVE"
-	description = "Terraform Acceptance Test MFA Policy Updated"
-	groups_included = [ "${data.okta_everyone_group.everyone-%d.id}" ]
-	fido_u2f = {
-		enroll = "OPTIONAL"
-	}
-	google_otp = {
-		enroll = "OPTIONAL"
-	}
-	okta_otp = {
-		enroll = "OPTIONAL"
-	}
-	okta_sms = {
-		enroll = "OPTIONAL"
-	}
-}
-`, rInt, policyMfa, name, name, rInt)
 }

--- a/okta/resource_policy_password_test.go
+++ b/okta/resource_policy_password_test.go
@@ -36,7 +36,7 @@ func TestAccOktaPolicyPassword(t *testing.T) {
 	mgr := newFixtureManager(policyPassword)
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
-	resourceName := fmt.Sprintf("%s.test", policySignOn)
+	resourceName := fmt.Sprintf("%s.test", policyPassword)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Despite what Okta's docs purport you cannot exclude groups from policies and you cannot include users from policy rules. Updating the provider to reflect that.