### PR TITLE
Enable request/response logging for debugging

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -5,7 +5,8 @@ import (
 	"time"
 
 	articulateOkta "github.com/articulate/oktasdk-go/okta"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/okta/okta-sdk-golang/okta"
 	"github.com/okta/okta-sdk-golang/okta/cache"
 )
@@ -30,6 +31,8 @@ type Config struct {
 
 func (c *Config) loadAndValidate() error {
 	httpClient := cleanhttp.DefaultClient()
+	httpClient.Transport = logging.NewTransport("Okta", httpClient.Transport)
+
 	articulateClient, err := articulateOkta.NewClientWithDomain(httpClient, c.orgName, c.domain, c.apiToken)
 
 	// add the Articulate Okta client object to Config


### PR DESCRIPTION
This makes debugging for developers & users of this provider easier by exposing all requests & responses in the log (when >DEBUG severity is set https://www.terraform.io/docs/internals/debugging.html).

This is to assist in debugging https://github.com/articulate/terraform-provider-okta/issues/162