### PR TITLE
Metadata endpoint handler must use same retry/backoff approach

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform v0.12.0
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/okta/okta-sdk-golang v0.1.0
@@ -20,4 +21,4 @@ require (
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
 )
 
-replace github.com/okta/okta-sdk-golang => github.com/articulate/okta-sdk-golang v1.0.3
+replace github.com/okta/okta-sdk-golang => github.com/articulate/okta-sdk-golang v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/articulate/okta-sdk-golang v1.0.3 h1:ayIwKdkjpStamPmuKEuZROH0fo9m/5dsFh3pAVJFF/g=
-github.com/articulate/okta-sdk-golang v1.0.3/go.mod h1:YiT3K58ZY8sxwPwDM8riggPXkhMQ8R4gIXtWGa9dgho=
+github.com/articulate/okta-sdk-golang v1.0.4 h1:+E53GjGGVmSZ1otsAIoifG2ycZuwuPlK6qj8RsYUSOc=
+github.com/articulate/okta-sdk-golang v1.0.4/go.mod h1:YiT3K58ZY8sxwPwDM8riggPXkhMQ8R4gIXtWGa9dgho=
 github.com/articulate/oktasdk-go v0.0.0-20190417182045-e41ed7befc56 h1:3oNDqjcsOep3W9pV9SQegVkViLCBGMu8ECIliq3B9dU=
 github.com/articulate/oktasdk-go v0.0.0-20190417182045-e41ed7befc56/go.mod h1:UTdWnHE/nQNjDvbmLBwxIHjJ3L8r3XlZZaqVDIUtu1I=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
@@ -222,6 +222,8 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uia
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/okta/api_supplement.go
+++ b/okta/api_supplement.go
@@ -2,9 +2,10 @@ package okta
 
 import (
 	"fmt"
-	"github.com/okta/okta-sdk-golang/okta"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/okta/okta-sdk-golang/okta"
 )
 
 // ApiSupplement not all APIs are supported by okta-sdk-golang, this will act as a supplement to the Okta SDK
@@ -24,7 +25,7 @@ func (m *ApiSupplement) GetSAMLMetdata(id, keyID string) ([]byte, *http.Response
 	req.Header.Add("Authorization", fmt.Sprintf("SSWS %s", m.token))
 	req.Header.Add("User-Agent", "Terraform Okta Provider")
 	req.Header.Add("Accept", "application/xml")
-	res, err := m.client.Do(req)
+	res, err := m.requestExecutor.DoWithRetries(req, 0)
 	if err != nil {
 		return nil, res, err
 	} else if res.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Due to a bug in Okta's SDK we had to handle our own request. In order to
use the same retry/backoff method we wrote in our forked version, we
just had to expose it publicly.