### PR TITLE
Support importing user by email or id

### DIFF
--- a/examples/okta_user/import.tf
+++ b/examples/okta_user/import.tf
@@ -1,0 +1,6 @@
+resource okta_user test {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "test-acc-replace_with_uuid@testing.com"
+  email      = "test-acc-replace_with_uuid@testing.com"
+}

--- a/okta/resource_app_saml_test.go
+++ b/okta/resource_app_saml_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/okta/okta-sdk-golang/okta"
 )
 
-func TestAccappSamlApplicationImport(t *testing.T) {
+func TestAccAppSamlImport(t *testing.T) {
 	ri := acctest.RandInt()
 	mgr := newFixtureManager(appSaml)
 	config := mgr.GetFixtures("import.tf", ri, t)


### PR DESCRIPTION
Pass whatever is passed to the import command to Okta. Let it error or return a user with an id. This will allow us to import users via email.

Fixes #194 (improvement determined through the discussion there)