### PR TITLE
Allow consumers to set client_id on oauth applications

### DIFF
--- a/examples/okta_app_oauth/oauth_app.tf
+++ b/examples/okta_app_oauth/oauth_app.tf
@@ -5,5 +5,6 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
+  custom_client_id           = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 }

--- a/okta/resource_app_oauth.go
+++ b/okta/resource_app_oauth.go
@@ -104,6 +104,12 @@ func resourceAppOAuth() *schema.Resource {
 				Computed:    true,
 				Description: "OAuth client ID.",
 			},
+			"custom_client_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "This property allows you to set your client_id.",
+			},
 			"omit_secret": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -391,6 +397,10 @@ func buildAppOAuth(d *schema.ResourceData, m interface{}) *okta.OpenIdConnectApp
 
 	if sec, ok := d.GetOk("client_basic_secret"); ok {
 		app.Credentials.OauthClient.ClientSecret = sec.(string)
+	}
+
+	if cid, ok := d.GetOk("custom_client_id"); ok {
+		app.Credentials.OauthClient.ClientId = cid.(string)
 	}
 
 	app.Settings = &okta.OpenIdConnectApplicationSettings{

--- a/okta/resource_app_oauth_test.go
+++ b/okta/resource_app_oauth_test.go
@@ -36,6 +36,7 @@ func TestAccOktaAppOauthBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "redirect_uris.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "response_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_secret", "something_from_somewhere"),
+					resource.TestCheckResourceAttr(resourceName, "client_id", "something_from_somewhere"),
 				),
 			},
 			{
@@ -47,6 +48,7 @@ func TestAccOktaAppOauthBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "browser"),
 					resource.TestCheckResourceAttr(resourceName, "grant_types.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "client_secret"),
+					resource.TestCheckResourceAttrSet(resourceName, "client_id"),
 				),
 			},
 		},


### PR DESCRIPTION
Allow oauth app client_id to be set using `custom_client_id`

Fixes #208 