### PR TITLE
Fix ocassional user schema panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,7 @@ For Release v3.0.9
 For Release v3.0.10
 
 * Add okta_network_zone resource 
+
+For Release v3.0.11
+
+* Fix ocassional panic when creating a user schema see https://github.com/articulate/terraform-provider-okta/issues/144

--- a/examples/okta_user/all_attributes.tf
+++ b/examples/okta_user/all_attributes.tf
@@ -3,7 +3,7 @@ resource "okta_user" "testAcc_replace_with_uuid" {
   first_name         = "TestAcc"
   last_name          = "Smith"
   login              = "test-acc-replace_with_uuid@testing.com"
-  email              = "test1-replace_with_uuid@testing.com"
+  email              = "test-acc-replace_with_uuid@testing.com"
   city               = "New York"
   cost_center        = "10"
   country_code       = "US"

--- a/okta/resource_user_test.go
+++ b/okta/resource_user_test.go
@@ -204,7 +204,7 @@ func TestAccOktaUser_updateAllAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "first_name", "TestAcc"),
 					resource.TestCheckResourceAttr(resourceName, "last_name", "Smith"),
 					resource.TestCheckResourceAttr(resourceName, "login", email),
-					resource.TestCheckResourceAttr(resourceName, "email", fmt.Sprintf("test1-%d@testing.com", ri)),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
 					resource.TestCheckResourceAttr(resourceName, "admin_roles.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "city", "New York"),
 					resource.TestCheckResourceAttr(resourceName, "cost_center", "10"),


### PR DESCRIPTION
If subschema does not come back in schema payload, backoff, and retry. Occasionally a read immediately after a created results in a missing subschema.

Fixes #144 

Need to keep an eye on this one, this issue appears to be very intermittent. I do believe this will correct it though, as hacky as it is.