### PR TITLE
Add support for Match Attribute in idp social resource

### DIFF
--- a/okta/idp.go
+++ b/okta/idp.go
@@ -69,6 +69,10 @@ var (
 			Optional: true,
 			Default:  "USERNAME",
 		},
+		"subject_match_attribute": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"profile_master": &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,

--- a/okta/idp_models.go
+++ b/okta/idp_models.go
@@ -169,6 +169,7 @@ type (
 
 	OIDCSubject struct {
 		MatchType        string                                       `json:"matchType,omitempty"`
+		MatchAttribute   string                                       `json:"matchAttribute,omitempty"`
 		UserNameTemplate *okta.ApplicationCredentialsUsernameTemplate `json:"userNameTemplate,omitempty"`
 	}
 

--- a/okta/resource_idp_social.go
+++ b/okta/resource_idp_social.go
@@ -94,6 +94,7 @@ func resourceIdpSocialRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("suspended_action", idp.Policy.Provisioning.Conditions.Suspended)
 	d.Set("profile_master", idp.Policy.Provisioning.ProfileMaster)
 	d.Set("subject_match_type", idp.Policy.Subject.MatchType)
+	d.Set("subject_match_attribute", idp.Policy.Subject.MatchAttribute)
 	d.Set("username_template", idp.Policy.Subject.UserNameTemplate.Template)
 	d.Set("client_id", idp.Protocol.Credentials.Client.ClientID)
 	d.Set("client_secret", idp.Protocol.Credentials.Client.ClientSecret)
@@ -143,7 +144,8 @@ func buildidpSocial(d *schema.ResourceData) *OIDCIdentityProvider {
 			MaxClockSkew: int64(d.Get("max_clock_skew").(int)),
 			Provisioning: NewIdpProvisioning(d),
 			Subject: &OIDCSubject{
-				MatchType: d.Get("subject_match_type").(string),
+				MatchType:      d.Get("subject_match_type").(string),
+				MatchAttribute: d.Get("subject_match_attribute").(string),
 				UserNameTemplate: &okta.ApplicationCredentialsUsernameTemplate{
 					Template: d.Get("username_template").(string),
 				},


### PR DESCRIPTION
I was not able to create a resource_idp_social because I needed to match the social provider key with a custom field in OKTA schema that I created. In order to do that match_type attribute should be set to CUSTOM. In that case match_attribute becomes required and it should contain the name of the custom field. 

Today there is no support for that match_attribute in the plugin. This PR addresses this issue. It modifies the schema and resource itself to support the additional attribute.