### PR TITLE
Add support modify permission in the user basic schema fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,9 @@ terraform-provider-okta*
 # go dep vendor directory
 vendor/
 
+# IDE
+.idea
+**/.DS_Store
+
 .env
 dist

--- a/examples/okta_user_base_schema/README.md
+++ b/examples/okta_user_base_schema/README.md
@@ -1,0 +1,3 @@
+# okta_user_basic_schema
+
+Represents an Okta User Basic Profile Attribute Schema. [See Okta documentation for more details](https://developer.okta.com/docs/reference/api/schemas/#update-user-profile-schema-property).

--- a/examples/okta_user_base_schema/basic.tf
+++ b/examples/okta_user_base_schema/basic.tf
@@ -1,0 +1,7 @@
+resource "okta_user_base_schema" "firstName" {
+  index       = "firstName"
+  title       = "First name"
+  type        = "string"
+
+  permissions = "READ_ONLY"
+}

--- a/examples/okta_user_base_schema/updated.tf
+++ b/examples/okta_user_base_schema/updated.tf
@@ -1,0 +1,7 @@
+resource "okta_user_base_schema" "firstName" {
+  index       = "firstName"
+  title       = "First name"
+  type        = "string"
+
+  permissions = "READ_WRITE"
+}

--- a/okta/provider.go
+++ b/okta/provider.go
@@ -144,6 +144,7 @@ func Provider() terraform.ResourceProvider {
 			templateEmail:          resourceTemplateEmail(),
 			trustedOrigin:          resourceTrustedOrigin(),
 			userSchema:             resourceUserSchema(),
+			userBaseSchema:         resourceUserBaseSchema(),
 
 			// Below resources will be deprecated, soon to be removed
 			"okta_user_schemas": resourceUserSchemas(),

--- a/okta/provider_sweeper_test.go
+++ b/okta/provider_sweeper_test.go
@@ -36,6 +36,7 @@ func TestMain(m *testing.M) {
 	setupSweeper(oktaGroup, sweepGroups)
 	setupSweeper(oktaUser, sweepUsers)
 	setupSweeper(userSchema, sweepUserSchema)
+	setupSweeper(userBaseSchema, sweepUserBaseSchema)
 	resource.TestMain(m)
 }
 

--- a/okta/resource_user_basic_schema.go
+++ b/okta/resource_user_basic_schema.go
@@ -1,0 +1,169 @@
+package okta
+
+import (
+	"fmt"
+	articulateOkta "github.com/articulate/oktasdk-go/okta"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const baseSchema = "base"
+
+func resourceUserBaseSchema() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUserBaseSchemaCreate,
+		Read:   resourceUserBaseSchemaRead,
+		Update: resourceUserBaseSchemaUpdate,
+		Delete: resourceUserBaseSchemaDelete,
+		Exists: resourceUserBaseSchemaExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"index": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Subschema unique string identifier",
+				ForceNew:    true,
+			},
+			"title": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Subschema title (display name)",
+			},
+			"type": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"string", "boolean", "number", "integer", "array", "object"}, false),
+				Description:  "Subschema type: string, boolean, number, integer, array, or object",
+				ForceNew:     true,
+			},
+			"array_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"string", "number", "interger", "reference"}, false),
+				Description:  "Subschema array type: string, number, interger, reference. Type field must be an array.",
+				ForceNew:     true,
+			},
+			"permissions": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"HIDE", "READ_ONLY", "READ_WRITE"}, false),
+				Description:  "SubSchema permissions: HIDE, READ_ONLY, or READ_WRITE.",
+				Default:      "READ_ONLY",
+			},
+			"master": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				// Accepting an empty value to allow for zero value (when provisioning is off)
+				ValidateFunc: validation.StringInSlice([]string{"PROFILE_MASTER", "OKTA", ""}, false),
+				Description:  "SubSchema profile manager, if not set it will inherit its setting.",
+			},
+		},
+	}
+}
+
+func resourceUserBaseSchemaCreate(d *schema.ResourceData, m interface{}) error {
+	if err := updateBaseSubschema(d, m); err != nil {
+		return err
+	}
+	d.SetId(d.Get("index").(string))
+
+	return resourceUserBaseSchemaRead(d, m)
+}
+
+func resourceUserBaseSchemaExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	subschema, err := getBaseSubSchema(d, m)
+
+	return subschema != nil, err
+}
+
+func resourceUserBaseSchemaRead(d *schema.ResourceData, m interface{}) error {
+	subschema, err := getBaseSubSchema(d, m)
+	if err != nil {
+		return err
+	} else if subschema == nil {
+		subschema, err = getBaseSubSchema(d, m)
+		if err != nil {
+			return err
+		} else if subschema == nil {
+			return fmt.Errorf("Okta did not return a subschema for \"%s\"", d.Id())
+		}
+	}
+
+	d.Set("title", subschema.Title)
+	d.Set("type", subschema.Type)
+	d.Set("index", subschema.Index)
+
+	if subschema.Master != nil {
+		d.Set("master", subschema.Master.Type)
+	}
+
+	if len(subschema.Permissions) > 0 {
+		d.Set("permissions", subschema.Permissions[0].Action)
+	}
+
+	return nil
+}
+
+func getBaseSubSchema(d *schema.ResourceData, m interface{}) (subschema *articulateOkta.BaseSubSchema, err error) {
+	var schema *articulateOkta.Schema
+	id := d.Id()
+
+	client := getClientFromMetadata(m)
+	schema, _, err = client.Schemas.GetUserSchema()
+	if err != nil {
+		return
+	}
+
+	for _, part := range schema.Definitions.Base.Properties {
+		if part.Index == id {
+			subschema = &part
+			return
+		}
+	}
+
+	return
+}
+
+func resourceUserBaseSchemaUpdate(d *schema.ResourceData, m interface{}) error {
+	if err := updateBaseSubschema(d, m); err != nil {
+		return err
+	}
+
+	return resourceUserBaseSchemaRead(d, m)
+}
+
+// can't delete Base
+func resourceUserBaseSchemaDelete(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+// create or modify a  subschema
+func updateBaseSubschema(d *schema.ResourceData, m interface{}) error {
+	client := getClientFromMetadata(m)
+
+	template := &articulateOkta.BaseSubSchema{
+		Index: d.Get("index").(string),
+		Title: d.Get("title").(string),
+		Type:  d.Get("type").(string),
+		Permissions: []articulateOkta.Permissions{
+			{
+				Action:    d.Get("permissions").(string),
+				Principal: "SELF",
+			},
+		},
+	}
+
+	if v, ok := d.GetOk("master"); ok {
+		template.Master = &articulateOkta.Master{Type: v.(string)}
+	}
+
+	_, _, err := client.Schemas.UpdateUserBaseSubSchema(*template)
+	if err != nil {
+		return fmt.Errorf("Error Updating User Base Subschema in Okta: %v", err)
+	}
+
+	return nil
+}

--- a/okta/resource_user_basic_schema_test.go
+++ b/okta/resource_user_basic_schema_test.go
@@ -1,0 +1,116 @@
+package okta
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+const baseTestProp = "firstName"
+
+func sweepUserBaseSchema(client *testClient) error {
+	_, _, err := client.artClient.Schemas.GetUserSchema()
+	if err != nil {
+		return err
+	}
+	var errorList []error
+
+	return condenseError(errorList)
+}
+
+func TestAccOktaUserBaseSchemas(t *testing.T) {
+	ri := acctest.RandInt()
+	mgr := newFixtureManager(userBaseSchema)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+	updated := mgr.GetFixtures("updated.tf", ri, t)
+	resourceName := fmt.Sprintf("%s.%s", userBaseSchema, baseTestProp)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil, // can't delete base properties
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testOktaUserBaseSchemasExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "index", baseTestProp),
+					resource.TestCheckResourceAttr(resourceName, "title", "First name"),
+					resource.TestCheckResourceAttr(resourceName, "type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "permissions", "READ_ONLY"),
+				),
+			},
+			{
+				Config: updated,
+				Check: resource.ComposeTestCheckFunc(
+					testOktaUserBaseSchemasExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "index", baseTestProp),
+					resource.TestCheckResourceAttr(resourceName, "title", "First name"),
+					resource.TestCheckResourceAttr(resourceName, "type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "permissions", "READ_WRITE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccuserBaseSchemaImport(t *testing.T) {
+	ri := acctest.RandInt()
+	resourceName := buildResourceFQN(userBaseSchema, ri)
+	mgr := newFixtureManager(userBaseSchema)
+	config := mgr.GetFixtures("basic.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return errors.New("Failed to import schema into state")
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testOktaUserBaseSchemasExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if exists, _ := testUserBaseSchemaExists(rs.Primary.ID); !exists {
+			return fmt.Errorf("Failed to find %s", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testUserBaseSchemaExists(index string) (bool, error) {
+	client := getClientFromMetadata(testAccProvider.Meta())
+	subschema, _, err := client.Schemas.GetUserSubSchemaIndex(baseSchema)
+	if err != nil {
+		return false, fmt.Errorf("Error Listing User Subschema in Okta: %v", err)
+	}
+	for _, key := range subschema {
+		if key == index {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
We are needed possibility to change permissions in the user schema via terraform-provider-okta.
This update provide this possibilities.