### PR TITLE
Add acceptance testing case for matching_attribute in idp social

### DIFF
--- a/examples/okta_idp_social/basic.tf
+++ b/examples/okta_idp_social/basic.tf
@@ -11,6 +11,20 @@ resource okta_idp_social facebook {
   client_id         = "abcd123"
   client_secret     = "abcd123"
   username_template = "idpuser.email"
+  match_type        = "CUSTOM_ATTRIBUTE"
+  match_attribute   = "customfieldId"
+}
+
+resource "okta_user_schema" "schema_custom" {
+  index       = "customfieldId"
+  title       = "Test Custom Field"
+  type        = "string"
+  description = "Test custom field"
+  required    = false
+  min_length  = 1
+  max_length  = 50
+  permissions = "READ_ONLY"
+  master      = "PROFILE_MASTER"
 }
 
 resource okta_idp_social google {

--- a/okta/resource_idp_social.go
+++ b/okta/resource_idp_social.go
@@ -46,6 +46,14 @@ func resourceIdpSocial() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"match_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"match_attribute": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"client_secret": &schema.Schema{
 				Type:      schema.TypeString,
 				Optional:  true,

--- a/okta/resource_idp_social_test.go
+++ b/okta/resource_idp_social_test.go
@@ -29,6 +29,8 @@ func TestAccIdpSocial(t *testing.T) {
 					resource.TestCheckResourceAttr(fbName, "client_id", "abcd123"),
 					resource.TestCheckResourceAttr(fbName, "client_secret", "abcd123"),
 					resource.TestCheckResourceAttr(fbName, "username_template", "idpuser.email"),
+					resource.TestCheckResourceAttr(fbName, "match_type", "CUSTOM_ATTRIBUTE"),
+					resource.TestCheckResourceAttr(fbName, "match_attribute", "customfieldId"),
 
 					resource.TestCheckResourceAttr(microName, "type", "MICROSOFT"),
 					resource.TestCheckResourceAttr(microName, "protocol_type", "OIDC"),


### PR DESCRIPTION
This PR is related to https://github.com/articulate/terraform-provider-okta/pull/229 PR that did not have acceptance test included. 

These changes will have a test case that will create a custom field in Okta schema and will use that custom field to in matching_attribute

One question I have - I had to modify the schema for in resource_idp_social.go so the validation won't fail during the acceptance testing. However, it was not required during the actual change.