### PR TITLE
Create Sign On Rule With Network Include or Exclude

### DIFF
--- a/examples/okta_policy_rule_signon/excluded_network.tf
+++ b/examples/okta_policy_rule_signon/excluded_network.tf
@@ -1,0 +1,26 @@
+data okta_group all {
+  name = "Everyone"
+}
+
+resource okta_policy_signon test {
+  name            = "testAcc_replace_with_uuid"
+  status          = "ACTIVE"
+  description     = "Terraform Acceptance Test SignOn Policy"
+  groups_included = ["${data.okta_group.all.id}"]
+}
+
+resource okta_policy_rule_signon test {
+  policyid           = "${okta_policy_signon.test.id}"
+  name               = "testAcc_replace_with_uuid"
+  access             = "DENY"
+  status             = "ACTIVE"
+  network_connection = "ZONE"
+  network_excludes   = ["${okta_network_zone.test.id}"]
+}
+
+resource "okta_network_zone" "test" {
+  name     = "testAcc_replace_with_uuid"
+  type     = "IP"
+  gateways = ["1.2.3.4/24", "2.3.4.5-2.3.4.15"]
+  proxies  = ["2.2.3.4/24", "3.3.4.5-3.3.4.15"]
+}

--- a/examples/okta_user_base_schema/basic.tf
+++ b/examples/okta_user_base_schema/basic.tf
@@ -1,7 +1,7 @@
 resource "okta_user_base_schema" "firstName" {
-  index       = "firstName"
-  title       = "First name"
-  type        = "string"
+  index = "firstName"
+  title = "First name"
+  type  = "string"
 
   permissions = "READ_ONLY"
 }

--- a/examples/okta_user_base_schema/updated.tf
+++ b/examples/okta_user_base_schema/updated.tf
@@ -1,7 +1,7 @@
 resource "okta_user_base_schema" "firstName" {
-  index       = "firstName"
-  title       = "First name"
-  type        = "string"
+  index = "firstName"
+  title = "First name"
+  type  = "string"
 
   permissions = "READ_WRITE"
 }

--- a/okta/policy_rule.go
+++ b/okta/policy_rule.go
@@ -137,20 +137,11 @@ func ensureNotDefaultRule(d *schema.ResourceData) error {
 }
 
 func getNetwork(d *schema.ResourceData) *articulateOkta.Network {
-	network := &articulateOkta.Network{
+	return &articulateOkta.Network{
 		Connection: d.Get("network_connection").(string),
+		Exclude:    convertInterfaceToStringArrNullable(d.Get("network_excludes")),
+		Include:    convertInterfaceToStringArrNullable(d.Get("network_includes")),
 	}
-
-	include := d.Get("network_includes")
-	exclude := d.Get("network_excludes")
-
-	if include != nil {
-		network.Include = convertInterfaceToStringArr(include)
-	} else if exclude != nil {
-		network.Exclude = convertInterfaceToStringArr(exclude)
-	}
-
-	return network
 }
 
 func getPolicyRule(d *schema.ResourceData, m interface{}) (*articulateOkta.Rule, error) {

--- a/okta/resource_policy_rule_sign_on_test.go
+++ b/okta/resource_policy_rule_sign_on_test.go
@@ -34,6 +34,7 @@ func TestAccOktaPolicyRuleSignOn(t *testing.T) {
 	mgr := newFixtureManager(policyRuleSignOn)
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
+	excludedNetwork := mgr.GetFixtures("excluded_network.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.test", policyRuleSignOn)
 
 	resource.Test(t, resource.TestCase{
@@ -60,6 +61,16 @@ func TestAccOktaPolicyRuleSignOn(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "session_lifetime", "240"),
 					resource.TestCheckResourceAttr(resourceName, "session_persistent", "false"),
 					resource.TestCheckResourceAttr(resourceName, "users_excluded.#", "1"),
+				),
+			},
+			{
+				Config: excludedNetwork,
+				Check: resource.ComposeTestCheckFunc(
+					ensureRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("testAcc_%d", ri)),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "access", "DENY"),
+					resource.TestCheckResourceAttr(resourceName, "network_connection", "ZONE"),
 				),
 			},
 		},


### PR DESCRIPTION
Okta's API only accepts and Include or Exclude. Instead of using the `if` mumbo jumbo just using my conversion or nullable logic and the `omitempty` tag will remove it when it is marshalled to JSON.

Fixes #236 
![Screen Shot 2019-08-09 at 3 37 21 PM](https://user-images.githubusercontent.com/14934291/62807721-b3d14d80-babb-11e9-908c-aea4bb62b300.png)
