### PR TITLE
Fixing mismatching idp_discovery_profile api

### DIFF
--- a/okta/idp_discovery_rule.go
+++ b/okta/idp_discovery_rule.go
@@ -13,15 +13,21 @@ type (
 	}
 
 	IdpDiscoveryRuleApp struct {
-		Exclude []string `json:"exclude"`
-		Include []string `json:"include"`
+		Exclude []*IdpDiscoveryRuleAppObj `json:"exclude"`
+		Include []*IdpDiscoveryRuleAppObj `json:"include"`
+	}
+
+	IdpDiscoveryRuleAppObj struct {
+		Type string `json:"type,omitempty"`
+		ID   string `json:"id,omitempty"`
+		Name string `json:"name,omitempty"`
 	}
 
 	IdpDiscoveryRuleConditions struct {
 		App            *IdpDiscoveryRuleApp            `json:"app"`
 		Network        *IdpDiscoveryRuleNetwork        `json:"network"`
-		Platform       *IdpDiscoveryRulePlatform       `json:"platform"`
-		UserIdentifier *IdpDiscoveryRuleUserIdentifier `json:"userIdentifier"`
+		Platform       *IdpDiscoveryRulePlatform       `json:"platform,omitempty"`
+		UserIdentifier *IdpDiscoveryRuleUserIdentifier `json:"userIdentifier,omitempty"`
 	}
 
 	IdpDiscoveryRuleIdp struct {
@@ -50,8 +56,8 @@ type (
 	}
 
 	IdpDiscoveryRulePlatform struct {
-		Exclude []interface{}                      `json:"exclude"`
-		Include []*IdpDiscoveryRulePlatformInclude `json:"include"`
+		Exclude []interface{}                      `json:"exclude,omitempty"`
+		Include []*IdpDiscoveryRulePlatformInclude `json:"include,omitempty"`
 	}
 
 	IdpDiscoveryRuleProvider struct {

--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -205,7 +205,7 @@ func buildIdentifier(d *schema.ResourceData) *IdpDiscoveryRuleUserIdentifier {
 			Patterns:  buildUserIdPatterns(d),
 		}
 	}
-	return nil;
+	return nil
 }
 
 func flattenUserIdPatterns(patterns []*IdpDiscoveryRulePattern) *schema.Set {
@@ -246,9 +246,9 @@ func flattenAppInclude(app *IdpDiscoveryRuleApp) *schema.Set {
 		flattened := make([]interface{}, len(app.Include))
 		for i, v := range app.Include {
 			flattened[i] = map[string]interface{}{
-				"id":    v.ID,
-				"name":  v.Name,
-				"type":  v.Type,
+				"id":   v.ID,
+				"name": v.Name,
+				"type": v.Type,
 			}
 		}
 	}
@@ -262,9 +262,9 @@ func flattenAppExclude(app *IdpDiscoveryRuleApp) *schema.Set {
 		flattened := make([]interface{}, len(app.Include))
 		for i, v := range app.Exclude {
 			flattened[i] = map[string]interface{}{
-				"id":    v.ID,
-				"name":  v.Name,
-				"type":  v.Type,
+				"id":   v.ID,
+				"name": v.Name,
+				"type": v.Type,
 			}
 		}
 	}
@@ -372,7 +372,7 @@ func buildIdpDiscoveryRule(d *schema.ResourceData, m interface{}) *IdpDiscoveryR
 				Include: convertInterfaceToStringArr(d.Get("network_includes")),
 				Exclude: convertInterfaceToStringArr(d.Get("network_excludes")),
 			},
-			Platform: buildPlatformInclude(d),
+			Platform:       buildPlatformInclude(d),
 			UserIdentifier: buildIdentifier(d),
 		},
 		Type:   idpDiscovery,

--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -41,6 +41,25 @@ var userIdPatternResource = &schema.Resource{
 	},
 }
 
+//https://developer.okta.com/docs/reference/api/policy/#application-and-app-instance-condition-object
+var appResource = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"type": &schema.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"APP", "APP_TYPE"}, false),
+		},
+		"name": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"id": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	},
+}
+
 func resourcePolicyRuleIdpDiscovery() *schema.Resource {
 	return &schema.Resource{
 		Exists:   resourcePolicyRuleIdpDiscoveryExists,
@@ -62,13 +81,13 @@ func resourcePolicyRuleIdpDiscovery() *schema.Resource {
 			},
 			"app_include": &schema.Schema{
 				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Elem:        appResource,
 				Optional:    true,
 				Description: "Applications to include in discovery rule",
 			},
 			"app_exclude": &schema.Schema{
 				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Elem:        appResource,
 				Optional:    true,
 				Description: "Applications to exclude in discovery rule",
 			},
@@ -112,10 +131,50 @@ func buildPlatformInclude(d *schema.ResourceData) *IdpDiscoveryRulePlatform {
 				})
 			}
 		}
+
+		return &IdpDiscoveryRulePlatform{
+			Include: includeList,
+		}
+	}
+	return nil
+
+}
+
+func buildAppConditions(d *schema.ResourceData) *IdpDiscoveryRuleApp {
+	includeList := []*IdpDiscoveryRuleAppObj{}
+
+	if v, ok := d.GetOk("app_include"); ok {
+		valueList := v.(*schema.Set).List()
+
+		for _, item := range valueList {
+			if value, ok := item.(map[string]interface{}); ok {
+				includeList = append(includeList, &IdpDiscoveryRuleAppObj{
+					ID:   getMapString(value, "id"),
+					Type: getMapString(value, "type"),
+					Name: getMapString(value, "name"),
+				})
+			}
+		}
 	}
 
-	return &IdpDiscoveryRulePlatform{
+	excludeList := []*IdpDiscoveryRuleAppObj{}
+	if v, ok := d.GetOk("app_exclude"); ok {
+		valueList := v.(*schema.Set).List()
+
+		for _, item := range valueList {
+			if value, ok := item.(map[string]interface{}); ok {
+				includeList = append(excludeList, &IdpDiscoveryRuleAppObj{
+					ID:   getMapString(value, "id"),
+					Type: getMapString(value, "type"),
+					Name: getMapString(value, "name"),
+				})
+			}
+		}
+	}
+
+	return &IdpDiscoveryRuleApp{
 		Include: includeList,
+		Exclude: excludeList,
 	}
 }
 
@@ -134,8 +193,19 @@ func buildUserIdPatterns(d *schema.ResourceData) []*IdpDiscoveryRulePattern {
 			}
 		}
 	}
-
 	return patternList
+}
+
+func buildIdentifier(d *schema.ResourceData) *IdpDiscoveryRuleUserIdentifier {
+
+	if uidType, ok := d.GetOkExists("user_identifier_type"); ok {
+		return &IdpDiscoveryRuleUserIdentifier{
+			Attribute: d.Get("user_identifier_attribute").(string),
+			Type:      uidType.(string),
+			Patterns:  buildUserIdPatterns(d),
+		}
+	}
+	return nil;
 }
 
 func flattenUserIdPatterns(patterns []*IdpDiscoveryRulePattern) *schema.Set {
@@ -167,6 +237,38 @@ func flattenPlatformInclude(platform *IdpDiscoveryRulePlatform) *schema.Set {
 		}
 	}
 	return schema.NewSet(schema.HashResource(platformIncludeResource), flattend)
+}
+
+func flattenAppInclude(app *IdpDiscoveryRuleApp) *schema.Set {
+	var flattend []interface{}
+
+	if app != nil && app.Include != nil {
+		flattened := make([]interface{}, len(app.Include))
+		for i, v := range app.Include {
+			flattened[i] = map[string]interface{}{
+				"id":    v.ID,
+				"name":  v.Name,
+				"type":  v.Type,
+			}
+		}
+	}
+	return schema.NewSet(schema.HashResource(appResource), flattend)
+}
+
+func flattenAppExclude(app *IdpDiscoveryRuleApp) *schema.Set {
+	var flattend []interface{}
+
+	if app != nil && app.Include != nil {
+		flattened := make([]interface{}, len(app.Include))
+		for i, v := range app.Exclude {
+			flattened[i] = map[string]interface{}{
+				"id":    v.ID,
+				"name":  v.Name,
+				"type":  v.Type,
+			}
+		}
+	}
+	return schema.NewSet(schema.HashResource(appResource), flattend)
 }
 
 func resourcePolicyRuleIdpDiscoveryExists(d *schema.ResourceData, m interface{}) (bool, error) {
@@ -224,8 +326,8 @@ func resourcePolicyRuleIdpDiscoveryRead(d *schema.ResourceData, m interface{}) e
 		"network_excludes":         convertStringArrToInterface(rule.Conditions.Network.Exclude),
 		"platform_include":         flattenPlatformInclude(rule.Conditions.Platform),
 		"user_identifier_patterns": flattenUserIdPatterns(rule.Conditions.UserIdentifier.Patterns),
-		"app_include":              convertStringSetToInterface(rule.Conditions.App.Include),
-		"app_exclude":              convertStringSetToInterface(rule.Conditions.App.Exclude),
+		"app_include":              flattenAppInclude(rule.Conditions.App),
+		"app_exclude":              flattenAppExclude(rule.Conditions.App),
 	})
 }
 
@@ -263,10 +365,7 @@ func buildIdpDiscoveryRule(d *schema.ResourceData, m interface{}) *IdpDiscoveryR
 			},
 		},
 		Conditions: &IdpDiscoveryRuleConditions{
-			App: &IdpDiscoveryRuleApp{
-				Include: convertInterfaceToStringSetNullable(d.Get("app_include")),
-				Exclude: convertInterfaceToStringSetNullable(d.Get("app_exclude")),
-			},
+			App: buildAppConditions(d),
 			Network: &IdpDiscoveryRuleNetwork{
 				Connection: d.Get("network_connection").(string),
 				// plural name here is vestigial due to old policy rule resources
@@ -274,11 +373,7 @@ func buildIdpDiscoveryRule(d *schema.ResourceData, m interface{}) *IdpDiscoveryR
 				Exclude: convertInterfaceToStringArr(d.Get("network_excludes")),
 			},
 			Platform: buildPlatformInclude(d),
-			UserIdentifier: &IdpDiscoveryRuleUserIdentifier{
-				Attribute: d.Get("user_identifier_attribute").(string),
-				Type:      d.Get("user_identifier_type").(string),
-				Patterns:  buildUserIdPatterns(d),
-			},
+			UserIdentifier: buildIdentifier(d),
 		},
 		Type:   idpDiscovery,
 		Name:   d.Get("name").(string),


### PR DESCRIPTION
Thanks for making an Okta terraform provider available for all!

We found a few issues with the idp_discovery_profile resource.  It appears it doesn't work if you didn't provide UserIdentifier or the Platform.  Additionally (and most importantly to our use case) the app config doesn't seem to match the [api for Application and App Instance Condition](https://developer.okta.com/docs/reference/api/policy/#application-and-app-instance-condition-object).

## User Identifier & Platform required

Without them provided, it was creating empty objects in the request `"userIdentifier": {}` or `"platform": {}` would cause the Okta api to throw an exception.

It looks like okta may have a deserialization issue and throws 500.  You can get around the platform one by adding the following to the `okta_policy_rule_idp_discovery`

```HCL
platform_include {
    type = "ANY"
    os_type = "ANY"
  }
```

However I haven't been able to find a userIdentifyer config that could be used to work around the issue without impacting the outcome of the policy.

## App Instance Condition Miss Match

The terraform currently defines the include and exclude as simply a list of string for the app id's.  It appears that the [api is expecting](https://developer.okta.com/docs/reference/api/policy/#application-and-app-instance-condition-object) an object like 

``` JSON
{
"app": {
    "include":[
      {
        "type": "APP_TYPE",
        "name":"yahoo_mail"
      },
      {
        "type": "APP",
        "id":"0oai0y4zt7hd2PSAP0h7"
      }
    ],
  }
```

This PR adds this shape as an allowed type.

## PR Notes
It also attempts to fix the required user identifier and invalid platform when empty issue.

This PR in its current state will possibly break unit tests and has not added new tests.  We have not tested this with `userIdentifier` or `platform` as our use case doesn't use those.

Also in full transparency, this is my first interaction with GO and terraform plugin development.  There are probably better ways to solve this issue, but due to my time limitations at this moment I don't have the time to dive deep into GO or terraform development and the code quality is not quite where I would normally like it to be before committing a PR.

At the moment I also don't have time to work on improving this PR, but figured I would share it incase anyone is running into a similar issue and would benefit or if anyone would have time to clean up and verify for the original use case.  In the future I may have time try to address any concerns or feedback as well as implement proper testing.

## Example Terraform that causes issue:

Supporting terraform:
```HCL

variable "idpName" {}
variable "issuer" {}
variable "ssoUrl" {}
variable "certBody" {}

resource okta_idp_saml_key cert {
  x5c = [ var.certBody  ]
}

resource okta_idp_saml idp {
  name                     = var.idpName
  acs_binding              = "HTTP-POST"
  acs_type                 = "INSTANCE"
  sso_url                  = var.ssoUrl
  sso_destination          = var.ssoUrl
  sso_binding              = "HTTP-POST"
  username_template        = "idpuser.subjectNameId"
  kid                      = okta_idp_saml_key.cert.id
  issuer                   = var.issuer
  response_signature_scope = "RESPONSE"
  request_signature_scope  = "REQUEST"
}

data "okta_group" "all" {
  name = "Everyone"
}

resource "okta_auth_server" "testAuthServer" {
  name        = "TEST_AUTH_SERVER"
  audiences   = ["test-aud"]
  description = "Temporary server to test idp integration"
}

resource "okta_auth_server_policy" "testAuthServerPolicy" {
  status           = "ACTIVE"
  name             = "Allow All Scopes To Everyone"
  description      = "Applies to all clients"
  priority         = 1
  client_whitelist = ["ALL_CLIENTS"]
  auth_server_id   = "${okta_auth_server.testAuthServer.id}"
}

resource "okta_auth_server_policy_rule" "policy_rule" {
  auth_server_id       = "${okta_auth_server.testAuthServer.id}"
  policy_id            = "${okta_auth_server_policy.testAuthServerPolicy.id}"
  status               = "ACTIVE"
  name                 = "Default Policy"
  priority             = 1
  group_whitelist      = ["${data.okta_group.all.id}"]
  grant_type_whitelist = ["implicit", "authorization_code"]

  scope_whitelist = ["*"]
  access_token_lifetime_minutes = 15
  refresh_token_window_minutes = 1440
}

resource "okta_app_oauth" "testApp" {
  label          = "OktaDebugTestApp"
  status         = "ACTIVE"
  type           = "web"
  grant_types    = ["implicit", "authorization_code", "refresh_token"]
  redirect_uris  = ["https://oauthdebugger.com/debug"]
  response_types = ["token", "id_token", "code"]
}

data okta_policy accountPolicy {
  name = "Idp Discovery Policy"
  type = "IDP_DISCOVERY"
}
```

### Expected Terraform Module
```HCL
resource okta_policy_rule_idp_discovery test {
  policyid             = "${data.okta_policy.accountPolicy.id}"
  priority             = 1
  name                 = "TEST_APP_ROUTE"
  idp_type             = "SAML2"
  idp_id               = okta_idp_saml.idp.idp_id

  app_include = [ id = okta_app_oauth.testApp.id ]
}
```

### Working after patch
```HCL
resource okta_policy_rule_idp_discovery test {
  policyid             = "${data.okta_policy.accountPolicy.id}"
  priority             = 1
  name                 = "TEST_APP_ROUTE"
  idp_type             = "SAML2"
  idp_id               = okta_idp_saml.idp.idp_id

  app_include {
    type = "APP"
    id = okta_app_oauth.testApp.id
  }

}
```