### PR TITLE
Don't populate the user identifier if type is blank

### DIFF
--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -199,16 +199,15 @@ func buildUserIdPatterns(d *schema.ResourceData) []*sdk.IdpDiscoveryRulePattern 
 
 func buildIdentifier(d *schema.ResourceData) *sdk.IdpDiscoveryRuleUserIdentifier {
 
-	if uidType, ok := d.GetOkExists("user_identifier_type"); ok {
-		if uidType != "" {
-			return &sdk.IdpDiscoveryRuleUserIdentifier{
-				Attribute: d.Get("user_identifier_attribute").(string),
-				Type:      uidType.(string),
-				Patterns:  buildUserIdPatterns(d),
-			}
+	uidType := d.Get("user_identifier_type").(string)
+	if uidType != "" {
+		return &sdk.IdpDiscoveryRuleUserIdentifier{
+			Attribute: d.Get("user_identifier_attribute").(string),
+			Type:      uidType,
+			Patterns:  buildUserIdPatterns(d),
 		}
-		return nil
 	}
+
 	return nil
 }
 

--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -200,11 +200,14 @@ func buildUserIdPatterns(d *schema.ResourceData) []*sdk.IdpDiscoveryRulePattern 
 func buildIdentifier(d *schema.ResourceData) *sdk.IdpDiscoveryRuleUserIdentifier {
 
 	if uidType, ok := d.GetOkExists("user_identifier_type"); ok {
-		return &sdk.IdpDiscoveryRuleUserIdentifier{
-			Attribute: d.Get("user_identifier_attribute").(string),
-			Type:      uidType.(string),
-			Patterns:  buildUserIdPatterns(d),
+		if uidType != "" {
+			return &sdk.IdpDiscoveryRuleUserIdentifier{
+				Attribute: d.Get("user_identifier_attribute").(string),
+				Type:      uidType.(string),
+				Patterns:  buildUserIdPatterns(d),
+			}
 		}
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
When creating an idp discovery rule, if you don't specify a body for the user identity role, terraform is generating an empty user identity block that is causing okta to throw a 500 as it is failing to deserialize the block.

This change makes the block only populated if the user identifier type is provided as it is a [required parameter](https://developer.okta.com/docs/reference/api/policy/#user-identifier-condition-object).  I couldn't figure out how to get it to omit the parameter if all children objects are empty.

There is probably a nicer way to do this in GO, but as I am new this was the quickest way I found to suppress this field with an inner if statement as I could figure out how to append it to the if above.