### PR TITLE
Fix state diff idp discovery

### DIFF
--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -244,13 +244,12 @@ func flattenAppInclude(app *sdk.IdpDiscoveryRuleApp) *schema.Set {
 	var flattend []interface{}
 
 	if app != nil && app.Include != nil {
-		flattened := make([]interface{}, len(app.Include))
-		for i, v := range app.Include {
-			flattened[i] = map[string]interface{}{
+		for _, v := range app.Include {
+			flattend = append(flattend, map[string]interface{}{
 				"id":   v.ID,
 				"name": v.Name,
 				"type": v.Type,
-			}
+			})
 		}
 	}
 	return schema.NewSet(schema.HashResource(appResource), flattend)
@@ -260,13 +259,12 @@ func flattenAppExclude(app *sdk.IdpDiscoveryRuleApp) *schema.Set {
 	var flattend []interface{}
 
 	if app != nil && app.Include != nil {
-		flattened := make([]interface{}, len(app.Include))
-		for i, v := range app.Exclude {
-			flattened[i] = map[string]interface{}{
+		for _, v := range app.Exclude {
+			flattend = append(flattend, map[string]interface{}{
 				"id":   v.ID,
 				"name": v.Name,
 				"type": v.Type,
-			}
+			})
 		}
 	}
 	return schema.NewSet(schema.HashResource(appResource), flattend)

--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -228,13 +228,12 @@ func flattenPlatformInclude(platform *sdk.IdpDiscoveryRulePlatform) *schema.Set 
 	var flattend []interface{}
 
 	if platform != nil && platform.Include != nil {
-		flattened := make([]interface{}, len(platform.Include))
-		for i, v := range platform.Include {
-			flattened[i] = map[string]interface{}{
+		for _, v := range platform.Include {
+			flattend = append(flattend, map[string]interface{}{
 				"os_expression": v.Os.Expression,
 				"os_type":       v.Os.Type,
 				"type":          v.Type,
-			}
+			})
 		}
 	}
 	return schema.NewSet(schema.HashResource(platformIncludeResource), flattend)

--- a/okta/resource_policy_rule_idp_discovery.go
+++ b/okta/resource_policy_rule_idp_discovery.go
@@ -225,33 +225,33 @@ func flattenUserIdPatterns(patterns []*sdk.IdpDiscoveryRulePattern) *schema.Set 
 }
 
 func flattenPlatformInclude(platform *sdk.IdpDiscoveryRulePlatform) *schema.Set {
-	var flattend []interface{}
+	var flattened []interface{}
 
 	if platform != nil && platform.Include != nil {
 		for _, v := range platform.Include {
-			flattend = append(flattend, map[string]interface{}{
+			flattened = append(flattened, map[string]interface{}{
 				"os_expression": v.Os.Expression,
 				"os_type":       v.Os.Type,
 				"type":          v.Type,
 			})
 		}
 	}
-	return schema.NewSet(schema.HashResource(platformIncludeResource), flattend)
+	return schema.NewSet(schema.HashResource(platformIncludeResource), flattened)
 }
 
 func flattenAppInclude(app *sdk.IdpDiscoveryRuleApp) *schema.Set {
-	var flattend []interface{}
+	var flattened []interface{}
 
 	if app != nil && app.Include != nil {
 		for _, v := range app.Include {
-			flattend = append(flattend, map[string]interface{}{
+			flattened = append(flattened, map[string]interface{}{
 				"id":   v.ID,
 				"name": v.Name,
 				"type": v.Type,
 			})
 		}
 	}
-	return schema.NewSet(schema.HashResource(appResource), flattend)
+	return schema.NewSet(schema.HashResource(appResource), flattened)
 }
 
 func flattenAppExclude(app *sdk.IdpDiscoveryRuleApp) *schema.Set {


### PR DESCRIPTION
Found that in the commit where I fixed the app conditions of the idp discovery policy, I copied an example from the flatten platform which had a typo in it.

I have fixed that typo then noticed that it was still detecting a diff for apps even when there was no diff, after debugging I found that the flattened array was still empty.  Not sure why from a GO perspective but I noticed in other methods the append operation used (and appeared to work) so I adopted that.