### PR TITLE
Make the user info url and binding optional

### DIFF
--- a/okta/idp.go
+++ b/okta/idp.go
@@ -119,9 +119,20 @@ var (
 		Computed: true,
 	}
 
+	optionalUrlSchema = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+
 	bindingSchema = &schema.Schema{
 		Type:         schema.TypeString,
 		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"HTTP-POST", "HTTP-REDIRECT"}, false),
+	}
+
+	optionalBindingSchema = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"HTTP-POST", "HTTP-REDIRECT"}, false),
 	}
 

--- a/okta/resource_idp_oidc.go
+++ b/okta/resource_idp_oidc.go
@@ -28,8 +28,8 @@ func resourceIdpOidc() *schema.Resource {
 			"authorization_binding": bindingSchema,
 			"token_url":             urlSchema,
 			"token_binding":         bindingSchema,
-			"user_info_url":         urlSchema,
-			"user_info_binding":     bindingSchema,
+			"user_info_url":         optionalUrlSchema,
+			"user_info_binding":     optionalBindingSchema,
 			"jwks_url":              urlSchema,
 			"jwks_binding":          bindingSchema,
 			"acs_binding":           bindingSchema,
@@ -141,8 +141,10 @@ func resourceIdpRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func syncEndpoint(key string, e *sdk.Endpoint, d *schema.ResourceData) {
-	d.Set(key+"_binding", e.Binding)
-	d.Set(key+"_url", e.URL)
+	if e != nil {
+		d.Set(key+"_binding", e.Binding)
+		d.Set(key+"_url", e.URL)
+	}
 }
 
 func resourceIdpUpdate(d *schema.ResourceData, m interface{}) error {

--- a/sdk/idp_models.go
+++ b/sdk/idp_models.go
@@ -216,8 +216,14 @@ func (i *BasicIdp) IsIDP() bool {
 }
 
 func GetEndpoint(d *schema.ResourceData, key string) *Endpoint {
-	return &Endpoint{
-		Binding: d.Get(fmt.Sprintf("%s_binding", key)).(string),
-		URL:     d.Get(fmt.Sprintf("%s_url", key)).(string),
+	binding := d.Get(fmt.Sprintf("%s_binding", key)).(string)
+	url := d.Get(fmt.Sprintf("%s_url", key)).(string)
+
+	if binding != "" && url != "" {
+		return &Endpoint{
+			Binding: binding,
+			URL:     url,
+		}
 	}
+	return nil
 }


### PR DESCRIPTION
The user info url and binding are optional for oidc idp configuration (as per the okta ui), the terraform was requiring it.

The api documentation has all those endpoints readonly so I cant trust those for this one.

![image](https://user-images.githubusercontent.com/360176/63529649-ff7bf200-c4d2-11e9-8f4f-a026e550fbe0.png)
