### PR TITLE
Update to Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     # needed for the snap pipe:
     - snapd
 go:
-- 1.12.x
+- 1.13.x
 install:
 # needed for the snap pipe:
 - sudo snap install snapcraft --classic

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This provider plugin is maintained by the Terraform team at [Articulate](https:/
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x
-- [Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
 
 ## Demo
 


### PR DESCRIPTION
fixes #267 

From release notes: `As of Go 1.13, the go command by default downloads and authenticates modules using the Go module mirror and Go checksum database run by Google. `