### PR TITLE
expose external_name to user profile

### DIFF
--- a/okta/user_schema.go
+++ b/okta/user_schema.go
@@ -102,6 +102,13 @@ var (
 			ValidateFunc: validation.StringInSlice([]string{"PROFILE_MASTER", "OKTA", ""}, false),
 			Description:  "SubSchema profile manager, if not set it will inherit its setting.",
 		},
+		"external_name": &schema.Schema{
+			Type:        schema.TypeString,
+			Required:    false,
+			Optional:    true,
+			Description: "Subschema external name",
+			ForceNew:    true,
+		},
 	}
 
 	userBaseSchemaSchema = map[string]*schema.Schema{
@@ -161,6 +168,7 @@ func syncUserSchema(d *schema.ResourceData, subschema *sdk.UserSubSchema) error 
 	d.Set("min_length", subschema.MinLength)
 	d.Set("max_length", subschema.MaxLength)
 	d.Set("scope", subschema.Scope)
+	d.Set("external_name", subschema.ExternalName)
 
 	if subschema.Items != nil {
 		d.Set("array_type", subschema.Items.Type)
@@ -261,12 +269,13 @@ func getUserSubSchema(d *schema.ResourceData) *sdk.UserSubSchema {
 				Principal: "SELF",
 			},
 		},
-		Scope:     d.Get("scope").(string),
-		Enum:      convertInterfaceToStringArrNullable(d.Get("enum")),
-		Master:    getNullableItem(d, "master"),
-		Items:     getNullableItem(d, "array_type"),
-		MinLength: getNullableInt(d, "min_length"),
-		MaxLength: getNullableInt(d, "max_length"),
-		OneOf:     getNullableOneOf(d),
+		Scope:        d.Get("scope").(string),
+		Enum:         convertInterfaceToStringArrNullable(d.Get("enum")),
+		Master:       getNullableItem(d, "master"),
+		Items:        getNullableItem(d, "array_type"),
+		MinLength:    getNullableInt(d, "min_length"),
+		MaxLength:    getNullableInt(d, "max_length"),
+		OneOf:        getNullableOneOf(d),
+		ExternalName: d.Get("external_name").(string),
 	}
 }

--- a/sdk/user_schema_models.go
+++ b/sdk/user_schema_models.go
@@ -37,21 +37,22 @@ type (
 	}
 
 	UserSubSchema struct {
-		Description string                  `json:"description,omitempty"`
-		Enum        []string                `json:"enum,omitempty"`
-		Format      string                  `json:"format,omitempty"`
-		Items       *UserSchemaItem         `json:"items,omitempty"`
-		Master      *UserSchemaItem         `json:"master,omitempty"`
-		MaxLength   *int                    `json:"maxLength,omitempty"`
-		MinLength   *int                    `json:"minLength,omitempty"`
-		Mutability  string                  `json:"mutability,omitempty"`
-		OneOf       []*UserSchemaEnum       `json:"oneOf,omitempty"`
-		Permissions []*UserSchemaPermission `json:"permissions,omitempty"`
-		Required    *bool                   `json:"required,omitempty"`
-		Scope       string                  `json:"scope,omitempty"`
-		Title       string                  `json:"title,omitempty"`
-		Type        string                  `json:"type,omitempty"`
-		Union       string                  `json:"union,omitempty"`
+		Description  string                  `json:"description,omitempty"`
+		Enum         []string                `json:"enum,omitempty"`
+		Format       string                  `json:"format,omitempty"`
+		Items        *UserSchemaItem         `json:"items,omitempty"`
+		Master       *UserSchemaItem         `json:"master,omitempty"`
+		MaxLength    *int                    `json:"maxLength,omitempty"`
+		MinLength    *int                    `json:"minLength,omitempty"`
+		Mutability   string                  `json:"mutability,omitempty"`
+		OneOf        []*UserSchemaEnum       `json:"oneOf,omitempty"`
+		Permissions  []*UserSchemaPermission `json:"permissions,omitempty"`
+		Required     *bool                   `json:"required,omitempty"`
+		Scope        string                  `json:"scope,omitempty"`
+		Title        string                  `json:"title,omitempty"`
+		Type         string                  `json:"type,omitempty"`
+		Union        string                  `json:"union,omitempty"`
+		ExternalName string                  `json:"externalName,omitempty"`
 	}
 
 	UserSubSchemaProperties struct {


### PR DESCRIPTION
The external name of the user profile was not exposed.

This pr exposes this field.  I don't quite understand the base vs subschema so this may also need to be added in the base, but this fix meets our needs.