### PR TITLE
custom_profile_attributes was renamed to profile

### DIFF
--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -306,7 +306,7 @@ func resourceAppOAuthRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("status", app.Status)
 	d.Set("sign_on_mode", app.SignOnMode)
 	d.Set("label", app.Label)
-	d.Set("custom_profile_attributes", app.Profile)
+	d.Set("profile", app.Profile)
 	d.Set("type", app.Settings.OauthClient.ApplicationType)
 	// Not setting client_secret, it is only provided on create for auth methods that require it
 	d.Set("client_id", app.Credentials.OauthClient.ClientId)
@@ -451,7 +451,7 @@ func buildAppOAuth(d *schema.ResourceData, m interface{}) *okta.OpenIdConnectApp
 	}
 	app.Visibility = buildVisibility(d)
 
-	if rawAttrs, ok := d.GetOk("custom_profile_attributes"); ok {
+	if rawAttrs, ok := d.GetOk("profile"); ok {
 		var attrs map[string]interface{}
 		str := rawAttrs.(string)
 		json.Unmarshal([]byte(str), &attrs)


### PR DESCRIPTION
As part of PR #265, custom_profile_attributes was supposed to be renamed to profile. I mistakenly didn't change this in all of the places I needed to.

This was not picked up by the acceptance tests. While they check that the application schema is correct, they don't check that the application built in Okta reflects this schema.

Is this how all of the tests work? Is there something specifically wrong with my tests?

Apologies for the questions, this is my first experience with both Go and Terraform.