### PR TITLE
Allow app_users and app_group_assignments to have optional profile

### DIFF
--- a/examples/okta_app_oauth/custom_attributes.tf
+++ b/examples/okta_app_oauth/custom_attributes.tf
@@ -7,8 +7,8 @@ resource "okta_app_oauth" "test" {
   client_basic_secret        = "something_from_somewhere"
   custom_client_id           = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
-  
-  profile  = <<JSON
+
+  profile = <<JSON
   {
     "customAttribute123": "testing-custom-attribute"
   }

--- a/examples/okta_app_oauth/group_for_groups_claim.tf
+++ b/examples/okta_app_oauth/group_for_groups_claim.tf
@@ -1,4 +1,3 @@
-
 // A groups claim allows for groups to be injected into ID tokens or access tokens.
 // A group whitelist allows for limiting the groups injected on a per-application basis to
 // reduce the size of the tokens. In reality, you would include the group ID in the 
@@ -19,7 +18,7 @@ resource "okta_app_oauth" "test" {
   client_basic_secret        = "something_from_somewhere"
   custom_client_id           = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
-  
+
   profile = <<JSON
    {
     "groups": {

--- a/examples/okta_app_user/basic_profile.tf
+++ b/examples/okta_app_user/basic_profile.tf
@@ -1,0 +1,45 @@
+resource okta_app_saml test {
+  label             = "testAcc_replace_with_uuid"
+  preconfigured_app = "google"
+
+  app_settings_json = <<JSON
+  {
+    "afwOnly": false,
+    "domain": "articulate"
+  }
+JSON
+
+  lifecycle {
+    ignore_changes = ["users", "groups"]
+  }
+}
+
+resource okta_user test {
+  first_name = "TestAcc"
+  last_name  = "Smith"
+  login      = "testAcc_replace_with_uuid@example.com"
+  email      = "testAcc_replace_with_uuid@example.com"
+}
+
+resource okta_app_user_schema test {
+  app_id      = "${okta_app_saml.test.id}"
+  index       = "testCustom"
+  title       = "terraform acceptance test"
+  type        = "string"
+  description = "terraform acceptance test updated"
+  required    = true
+  master      = "OKTA"
+  scope       = "SELF"
+}
+
+resource okta_app_user test {
+  app_id   = "${okta_app_saml.test.id}"
+  user_id  = "${okta_user.test.id}"
+  username = "${okta_user.test.email}"
+
+  profile = <<JSON
+{"testCustom":"testing"}
+JSON
+
+  depends_on = ["okta_app_user_schema.test"]
+}

--- a/okta/resource_okta_app_group_assignment.go
+++ b/okta/resource_okta_app_group_assignment.go
@@ -15,6 +15,7 @@ func resourceAppGroupAssignment() *schema.Resource {
 		Exists: resourceAppGroupAssignmentExists,
 		Read:   resourceAppGroupAssignmentRead,
 		Delete: resourceAppGroupAssignmentDelete,
+		Update: resourceAppGroupAssignmentUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -32,10 +33,15 @@ func resourceAppGroupAssignment() *schema.Resource {
 				Description: "Group associated with the application",
 				ForceNew:    true,
 			},
+			"priority": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"profile": &schema.Schema{
 				Type:      schema.TypeString,
 				StateFunc: normalizeDataJSON,
-				Computed:  true,
+				Optional:  true,
+				Default:   "{}",
 			},
 		},
 	}
@@ -52,11 +58,25 @@ func resourceAppGroupAssignmentExists(d *schema.ResourceData, m interface{}) (bo
 	return g != nil, err
 }
 
+func getAppGroupAssignment(d *schema.ResourceData) okta.ApplicationGroupAssignment {
+	var profile interface{}
+
+	rawProfile := d.Get("profile").(string)
+	// JSON is already validated
+	json.Unmarshal([]byte(rawProfile), &profile)
+	priority := d.Get("priority").(int)
+
+	return okta.ApplicationGroupAssignment{
+		Profile:  profile,
+		Priority: int64(priority),
+	}
+}
+
 func resourceAppGroupAssignmentCreate(d *schema.ResourceData, m interface{}) error {
 	assignment, _, err := getOktaClientFromMetadata(m).Application.CreateApplicationGroupAssignment(
 		d.Get("app_id").(string),
 		d.Get("group_id").(string),
-		okta.ApplicationGroupAssignment{},
+		getAppGroupAssignment(d),
 	)
 
 	if err != nil {
@@ -66,6 +86,22 @@ func resourceAppGroupAssignmentCreate(d *schema.ResourceData, m interface{}) err
 	d.SetId(assignment.Id)
 
 	return resourceAppGroupAssignmentRead(d, m)
+}
+
+func resourceAppGroupAssignmentUpdate(d *schema.ResourceData, m interface{}) error {
+	client := getOktaClientFromMetadata(m)
+	// Create actually does a PUT
+	_, _, err := client.Application.CreateApplicationGroupAssignment(
+		d.Get("app_id").(string),
+		d.Get("group_id").(string),
+		getAppGroupAssignment(d),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return resourceAppUserRead(d, m)
 }
 
 func resourceAppGroupAssignmentRead(d *schema.ResourceData, m interface{}) error {
@@ -85,6 +121,7 @@ func resourceAppGroupAssignmentRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	d.Set("profile", string(jsonProfile))
+	d.Set("priority", g.Priority)
 
 	return nil
 }

--- a/okta/resource_okta_app_group_assignment_test.go
+++ b/okta/resource_okta_app_group_assignment_test.go
@@ -26,7 +26,7 @@ func TestAccAppGroupAssignment_crud(t *testing.T) {
 					ensureAppGroupAssignmentExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "group_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "profile"),
+					resource.TestCheckResourceAttr(resourceName, "profile", "{}"),
 				),
 			},
 		},

--- a/okta/resource_okta_app_user.go
+++ b/okta/resource_okta_app_user.go
@@ -1,6 +1,8 @@
 package okta
 
 import (
+	"encoding/json"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/okta/okta-sdk-golang/okta"
 )
@@ -40,7 +42,8 @@ func resourceAppUser() *schema.Resource {
 			"profile": &schema.Schema{
 				Type:      schema.TypeString,
 				StateFunc: normalizeDataJSON,
-				Computed:  true,
+				Optional:  true,
+				Default:   "{}",
 			},
 		},
 	}
@@ -115,6 +118,12 @@ func resourceAppUserDelete(d *schema.ResourceData, m interface{}) error {
 }
 
 func getAppUser(d *schema.ResourceData) *okta.AppUser {
+	var profile interface{}
+
+	rawProfile := d.Get("profile").(string)
+	// JSON is already validated
+	json.Unmarshal([]byte(rawProfile), &profile)
+
 	return &okta.AppUser{
 		Id: d.Get("user_id").(string),
 		Credentials: &okta.AppUserCredentials{
@@ -123,5 +132,6 @@ func getAppUser(d *schema.ResourceData) *okta.AppUser {
 				Value: d.Get("password").(string),
 			},
 		},
+		Profile: profile,
 	}
 }

--- a/okta/resource_okta_app_user_test.go
+++ b/okta/resource_okta_app_user_test.go
@@ -15,6 +15,7 @@ func TestAccOktaAppUser_crud(t *testing.T) {
 	mgr := newFixtureManager(appUser)
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	update := mgr.GetFixtures("update.tf", ri, t)
+	basicProfile := mgr.GetFixtures("basic_profile.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,6 +38,16 @@ func TestAccOktaAppUser_crud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("testAcc_%d", ri)),
+				),
+			},
+			{
+				Config: basicProfile,
+				Check: resource.ComposeTestCheckFunc(
+					ensureAppUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "app_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "user_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", fmt.Sprintf("testAcc_%d@example.com", ri)),
+					resource.TestCheckResourceAttr(resourceName, "profile", "{\"testCustom\":\"testing\"}"),
 				),
 			},
 		},


### PR DESCRIPTION
Allow profile to be set. Note: I had a lot of trouble finding a working group example. All attempts resulted in Okta API errors. It is possible this configuration only works once API Integration is setup.

fixes #234 
fixes #244 