### PR TITLE
Extend refresh token window

### DIFF
--- a/examples/okta_auth_server/README.md
+++ b/examples/okta_auth_server/README.md
@@ -4,3 +4,4 @@ Represents an Authorization Server. [See Okta documentation for more details](ht
 
 * Example of a simple auth server and data source [can be found here](./datasource.tf)
 * Example of an auth server with some of its nested resources [can be found here](./full_stack.tf)
+* Example of an auth server whitelisting a specific client [can be found here](./full_stack_with_client.tf)

--- a/examples/okta_auth_server/full_stack_with_client.tf
+++ b/examples/okta_auth_server/full_stack_with_client.tf
@@ -26,7 +26,7 @@ resource "okta_auth_server_policy" "test" {
   name             = "test"
   description      = "update"
   priority         = 1
-  client_whitelist = ["ALL_CLIENTS"]
+  client_whitelist = ["${okta_app_oauth.test.id}"]
 }
 
 data "okta_group" "all" {
@@ -41,4 +41,13 @@ resource "okta_auth_server_policy_rule" "test" {
   priority             = 1
   group_whitelist      = ["${data.okta_group.all.id}"]
   grant_type_whitelist = ["password", "implicit"]
+}
+
+resource "okta_app_oauth" "test" {
+  status         = "ACTIVE"
+  label          = "test"
+  type           = "web"
+  grant_types    = ["implicit", "authorization_code"]
+  redirect_uris  = ["https://localhost:8443/redirect_uri/"]
+  response_types = ["code", "token", "id_token"]
 }

--- a/okta/resource_okta_auth_server_policy_rule.go
+++ b/okta/resource_okta_auth_server_policy_rule.go
@@ -70,8 +70,8 @@ func resourceAuthServerPolicyRule() *schema.Resource {
 			"refresh_token_window_minutes": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				// 10 mins - 90 days
-				ValidateFunc: validation.IntBetween(10, 129600),
+				// 10 mins - 5 years
+				ValidateFunc: validation.IntBetween(10, 2628000),
 				Default:      10080,
 			},
 			"inline_hook_id": &schema.Schema{

--- a/okta/resource_okta_auth_server_test.go
+++ b/okta/resource_okta_auth_server_test.go
@@ -90,7 +90,7 @@ func TestAccOktaAuthServer_fullStack(t *testing.T) {
 	scopeName := fmt.Sprintf("%s.test", authServerScope)
 	mgr := newFixtureManager("okta_auth_server")
 	config := mgr.GetFixtures("full_stack.tf", ri, t)
-	updatedConfig := mgr.GetFixtures("full_stack_updated.tf", ri, t)
+	updatedConfig := mgr.GetFixtures("full_stack_with_client.tf", ri, t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -124,6 +124,7 @@ func TestAccOktaAuthServer_fullStack(t *testing.T) {
 					resource.TestCheckResourceAttr(scopeName, "name", "test:something"),
 					resource.TestCheckResourceAttr(claimName, "name", "test"),
 					resource.TestCheckResourceAttr(policyName, "name", "test"),
+					resource.TestCheckResourceAttr(policyName, "client_whitelist.#", "1"),
 					resource.TestCheckResourceAttr(ruleName, "name", "test"),
 				),
 			},


### PR DESCRIPTION
* There is a new 5y upper limit on the refresh token window, updating validation logic to match.
* Add a `client_whitelist` example that refers to an app

This closes #283, closes #284 