### PR TITLE
Add pattern, min/max length to base schema

### DIFF
--- a/examples/okta_user_base_schema/basic.tf
+++ b/examples/okta_user_base_schema/basic.tf
@@ -4,4 +4,6 @@ resource "okta_user_base_schema" "firstName" {
   permissions = "READ_ONLY"
   title       = "First name"
   type        = "string"
+  min_length  = 1
+  max_length  = 50
 }

--- a/examples/okta_user_base_schema/updated.tf
+++ b/examples/okta_user_base_schema/updated.tf
@@ -5,4 +5,6 @@ resource "okta_user_base_schema" "firstName" {
   master      = "PROFILE_MASTER"
   permissions = "READ_WRITE"
   required    = true
+  min_length  = 1
+  max_length  = 50
 }

--- a/examples/okta_user_base_schema/username.tf
+++ b/examples/okta_user_base_schema/username.tf
@@ -1,0 +1,10 @@
+resource "okta_user_base_schema" "login" {
+  index       = "login"
+  title       = "Username"
+  type        = "string"
+  master      = "PROFILE_MASTER"
+  permissions = "READ_ONLY"
+  required    = true
+  min_length  = 4
+  max_length  = 70
+}

--- a/okta/resource_okta_app_user_base_schema.go
+++ b/okta/resource_okta_app_user_base_schema.go
@@ -82,9 +82,12 @@ func resourceAppUserBaseSchemaDelete(d *schema.ResourceData, m interface{}) erro
 // create or modify a  subschema
 func updateAppUserBaseSubschema(d *schema.ResourceData, m interface{}) error {
 	schema := &sdk.UserSubSchema{
-		Master: getNullableMaster(d),
-		Title:  d.Get("title").(string),
-		Type:   d.Get("type").(string),
+		Master:    getNullableMaster(d),
+		MinLength: getNullableInt(d, "min_length"),
+		MaxLength: getNullableInt(d, "max_length"),
+		Title:     d.Get("title").(string),
+		Type:      d.Get("type").(string),
+		Pattern:   d.Get("pattern").(string),
 		Permissions: []*sdk.UserSchemaPermission{
 			{
 				Action:    d.Get("permissions").(string),

--- a/okta/resource_okta_user_base_schema.go
+++ b/okta/resource_okta_user_base_schema.go
@@ -79,9 +79,12 @@ func resourceUserBaseSchemaDelete(d *schema.ResourceData, m interface{}) error {
 // create or modify a  subschema
 func updateBaseSubschema(d *schema.ResourceData, m interface{}) error {
 	schema := &sdk.UserSubSchema{
-		Master: getNullableMaster(d),
-		Title:  d.Get("title").(string),
-		Type:   d.Get("type").(string),
+		Master:    getNullableMaster(d),
+		MinLength: getNullableInt(d, "min_length"),
+		MaxLength: getNullableInt(d, "max_length"),
+		Title:     d.Get("title").(string),
+		Type:      d.Get("type").(string),
+		Pattern:   d.Get("pattern").(string),
 		Permissions: []*sdk.UserSchemaPermission{
 			{
 				Action:    d.Get("permissions").(string),

--- a/okta/resource_okta_user_base_schema_test.go
+++ b/okta/resource_okta_user_base_schema_test.go
@@ -28,7 +28,9 @@ func TestAccOktaUserBaseSchema_crud(t *testing.T) {
 	mgr := newFixtureManager(userBaseSchema)
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updated := mgr.GetFixtures("updated.tf", ri, t)
+	usernamePattern := mgr.GetFixtures("username.tf", ri, t)
 	resourceName := fmt.Sprintf("%s.%s", userBaseSchema, baseTestProp)
+	loginResourceName := fmt.Sprintf("%s.login", userBaseSchema)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -43,6 +45,8 @@ func TestAccOktaUserBaseSchema_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "title", "First name"),
 					resource.TestCheckResourceAttr(resourceName, "type", "string"),
 					resource.TestCheckResourceAttr(resourceName, "permissions", "READ_ONLY"),
+					resource.TestCheckResourceAttr(resourceName, "min_length", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_length", "50"),
 				),
 			},
 			{
@@ -54,6 +58,8 @@ func TestAccOktaUserBaseSchema_crud(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "string"),
 					resource.TestCheckResourceAttr(resourceName, "required", "true"),
 					resource.TestCheckResourceAttr(resourceName, "permissions", "READ_WRITE"),
+					resource.TestCheckResourceAttr(resourceName, "min_length", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_length", "50"),
 				),
 			},
 			{
@@ -66,6 +72,19 @@ func TestAccOktaUserBaseSchema_crud(t *testing.T) {
 
 					return nil
 				},
+			},
+			{
+				Config: usernamePattern,
+				Check: resource.ComposeTestCheckFunc(
+					testOktaUserBaseSchemasExists(loginResourceName),
+					resource.TestCheckResourceAttr(loginResourceName, "index", "login"),
+					resource.TestCheckResourceAttr(loginResourceName, "title", "Username"),
+					resource.TestCheckResourceAttr(loginResourceName, "type", "string"),
+					resource.TestCheckResourceAttr(loginResourceName, "required", "true"),
+					resource.TestCheckResourceAttr(loginResourceName, "permissions", "READ_ONLY"),
+					resource.TestCheckResourceAttr(loginResourceName, "min_length", "5"),
+					resource.TestCheckResourceAttr(loginResourceName, "max_length", "70"),
+				),
 			},
 		},
 	})

--- a/okta/user_schema.go
+++ b/okta/user_schema.go
@@ -158,6 +158,11 @@ var (
 			Description:  "Subschema type: string, boolean, number, integer, array, or object",
 			ForceNew:     true,
 		},
+		"pattern": &schema.Schema{
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Restrict the username schema property to a particular regex pattern. Unlike the UI you must use a regex here.",
+		},
 		"permissions": &schema.Schema{
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -171,6 +176,18 @@ var (
 			// Accepting an empty value to allow for zero value (when provisioning is off)
 			ValidateFunc: validation.StringInSlice([]string{"PROFILE_MASTER", "OKTA", ""}, false),
 			Description:  "SubSchema profile manager, if not set it will inherit its setting.",
+		},
+		"min_length": &schema.Schema{
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Subschema of type string minimum length",
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+		"max_length": &schema.Schema{
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Subschema of type string maximum length",
+			ValidateFunc: validation.IntAtLeast(1),
 		},
 		"required": &schema.Schema{
 			Type:        schema.TypeBool,
@@ -220,6 +237,9 @@ func syncBaseUserSchema(d *schema.ResourceData, subschema *sdk.UserSubSchema) {
 	d.Set("title", subschema.Title)
 	d.Set("type", subschema.Type)
 	d.Set("required", subschema.Required)
+	d.Set("pattern", subschema.Pattern)
+	d.Set("min_length", subschema.MinLength)
+	d.Set("max_length", subschema.MaxLength)
 
 	if subschema.Master != nil {
 		d.Set("master", subschema.Master.Type)

--- a/sdk/user_schema_models.go
+++ b/sdk/user_schema_models.go
@@ -52,6 +52,7 @@ type (
 		MinLength    *int                    `json:"minLength,omitempty"`
 		Mutability   string                  `json:"mutability,omitempty"`
 		OneOf        []*UserSchemaEnum       `json:"oneOf,omitempty"`
+		Pattern      string                  `json:"pattern,omitempty"`
 		Permissions  []*UserSchemaPermission `json:"permissions,omitempty"`
 		Required     *bool                   `json:"required,omitempty"`
 		Scope        string                  `json:"scope,omitempty"`

--- a/website/docs/r/app_user_base_schema.html.markdown
+++ b/website/docs/r/app_user_base_schema.html.markdown
@@ -38,6 +38,12 @@ The following arguments are supported:
 
 * `required` - (Optional) Whether the property is required for this application's users.
 
+* `pattern` - (Optional) Restrict `login` schema property to a particular regex.
+
+* `min_length` - (Optional) The minimum length of the user property value. Only applies to type `"string"`.
+
+* `max_length` - (Optional) The maximum length of the user property value. Only applies to type `"string"`.
+
 * `permissions` - (Optional) Access control permissions for the property. It can be set to `"READ_WRITE"`, `"READ_ONLY"`, `"HIDE"`.
 
 * `master` - (Optional) Master priority for the user schema property. It can be set to `"PROFILE_MASTER"` or `"OKTA"`.

--- a/website/docs/r/user_base_schema.html.markdown
+++ b/website/docs/r/user_base_schema.html.markdown
@@ -35,9 +35,15 @@ The following arguments are supported:
 
 * `required` - (Optional) Whether the property is required for this application's users.
 
+* `pattern` - (Optional) Restrict `login` schema property to a particular regex.
+
 * `permissions` - (Optional) Access control permissions for the property. It can be set to `"READ_WRITE"`, `"READ_ONLY"`, `"HIDE"`.
 
 * `master` - (Optional) Master priority for the user schema property. It can be set to `"PROFILE_MASTER"` or `"OKTA"`.
+
+* `min_length` - (Optional) The minimum length of the user property value. Only applies to type `"string"`.
+
+* `max_length` - (Optional) The maximum length of the user property value. Only applies to type `"string"`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Related to #294, currently blocked, it appears these values via the external API are READ_ONLY. Investigating. 