### PR TITLE
Auth server issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,3 +224,4 @@ BUG FIXES:
 BUG FIXES:
 
 * Ensure we safely sync auth server properties. [GH-299]
+* MANUAL rotation mode can only be set on an auth server on update. Ensure we run update after create for that scenario. [GH-287]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,3 +218,9 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * Remove resource from state on 404. [GH-269]
+
+## 3.0.29
+
+BUG FIXES:
+
+* Ensure we safely sync auth server properties. [GH-299]

--- a/examples/okta_auth_server/dependency.tf
+++ b/examples/okta_auth_server/dependency.tf
@@ -1,0 +1,9 @@
+resource okta_auth_server test {
+  name                      = "testAcc_replace_with_uuid"
+  audiences                 = ["api://selfservice_client_1"]
+}
+
+resource okta_auth_server test1 {
+  name                      = "testAcc_replace_with_uuid1"
+  audiences                 = ["api://selfservice_client_2"]
+}

--- a/examples/okta_auth_server/dependency.tf
+++ b/examples/okta_auth_server/dependency.tf
@@ -6,4 +6,5 @@ resource okta_auth_server test {
 resource okta_auth_server test1 {
   name                      = "testAcc_replace_with_uuid1"
   audiences                 = ["api://selfservice_client_2"]
+  credentials_rotation_mode = "MANUAL"
 }

--- a/okta/resource_okta_auth_server.go
+++ b/okta/resource_okta_auth_server.go
@@ -99,12 +99,22 @@ func buildAuthServer(d *schema.ResourceData) *sdk.AuthorizationServer {
 
 func resourceAuthServerCreate(d *schema.ResourceData, m interface{}) error {
 	authServer := buildAuthServer(d)
+
 	responseAuthServer, _, err := getSupplementFromMetadata(m).CreateAuthorizationServer(*authServer, nil)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(responseAuthServer.Id)
+
+	if d.Get("credentials_rotation_mode").(string) == "MANUAL" {
+		// Auth servers can only be set to manual on update. No clue why.
+		err = resourceAuthServerUpdate(d, m)
+
+		if err != nil {
+			return err
+		}
+	}
 
 	return resourceAuthServerRead(d, m)
 }

--- a/okta/resource_okta_auth_server.go
+++ b/okta/resource_okta_auth_server.go
@@ -128,10 +128,20 @@ func resourceAuthServerRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("audiences", convertStringSetToInterface(authServer.Audiences))
-	d.Set("credentials_rotation_mode", authServer.Credentials.Signing.RotationMode)
 	d.Set("kid", authServer.Credentials.Signing.Kid)
-	d.Set("credentials_next_rotation", authServer.Credentials.Signing.NextRotation.String())
-	d.Set("credentials_last_rotated", authServer.Credentials.Signing.LastRotated.String())
+
+	if authServer.Credentials != nil && authServer.Credentials.Signing != nil {
+		d.Set("credentials_rotation_mode", authServer.Credentials.Signing.RotationMode)
+
+		if authServer.Credentials.Signing.NextRotation != nil {
+			d.Set("credentials_next_rotation", authServer.Credentials.Signing.NextRotation.String())
+		}
+
+		if authServer.Credentials.Signing.LastRotated != nil {
+			d.Set("credentials_last_rotated", authServer.Credentials.Signing.LastRotated.String())
+		}
+	}
+
 	d.Set("description", authServer.Description)
 	d.Set("name", authServer.Name)
 	d.Set("status", authServer.Status)

--- a/okta/resource_okta_auth_server_test.go
+++ b/okta/resource_okta_auth_server_test.go
@@ -47,7 +47,7 @@ func TestAccOktaAuthServer_crud(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := fmt.Sprintf("%s.sun_also_rises", authServer)
 	name := buildResourceName(ri)
-	mgr := newFixtureManager("okta_auth_server")
+	mgr := newFixtureManager(authServer)
 	config := mgr.GetFixtures("basic.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("basic_updated.tf", ri, t)
 
@@ -88,7 +88,7 @@ func TestAccOktaAuthServer_fullStack(t *testing.T) {
 	ruleName := fmt.Sprintf("%s.test", authServerPolicyRule)
 	policyName := fmt.Sprintf("%s.test", authServerPolicy)
 	scopeName := fmt.Sprintf("%s.test", authServerScope)
-	mgr := newFixtureManager("okta_auth_server")
+	mgr := newFixtureManager(authServer)
 	config := mgr.GetFixtures("full_stack.tf", ri, t)
 	updatedConfig := mgr.GetFixtures("full_stack_with_client.tf", ri, t)
 
@@ -126,6 +126,36 @@ func TestAccOktaAuthServer_fullStack(t *testing.T) {
 					resource.TestCheckResourceAttr(policyName, "name", "test"),
 					resource.TestCheckResourceAttr(policyName, "client_whitelist.#", "1"),
 					resource.TestCheckResourceAttr(ruleName, "name", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOktaAuthServer_gh299(t *testing.T) {
+	ri := acctest.RandInt()
+	name := buildResourceName(ri)
+	resourceName := fmt.Sprintf("%s.test", authServer)
+	resource2Name := fmt.Sprintf("%s.test1", authServer)
+	mgr := newFixtureManager(authServer)
+	config := mgr.GetFixtures("dependency.tf", ri, t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: createCheckResourceDestroy(authServer, authServerExists),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					ensureResourceExists(resourceName, authServerExists),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "audiences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials_rotation_mode", "AUTO"),
+
+					resource.TestCheckResourceAttr(resource2Name, "name", name+"1"),
+					resource.TestCheckResourceAttr(resource2Name, "audiences.#", "1"),
+					resource.TestCheckResourceAttr(resource2Name, "credentials_rotation_mode", "AUTO"),
 				),
 			},
 		},

--- a/okta/resource_okta_auth_server_test.go
+++ b/okta/resource_okta_auth_server_test.go
@@ -155,7 +155,7 @@ func TestAccOktaAuthServer_gh299(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resource2Name, "name", name+"1"),
 					resource.TestCheckResourceAttr(resource2Name, "audiences.#", "1"),
-					resource.TestCheckResourceAttr(resource2Name, "credentials_rotation_mode", "AUTO"),
+					resource.TestCheckResourceAttr(resource2Name, "credentials_rotation_mode", "MANUAL"),
 				),
 			},
 		},


### PR DESCRIPTION
* Fix auth server issue that results in a panic. Turns out in certain circumstances Okta is not returning the expected credential parameters. When this happens, it results in a panic due to the way the struct is setup in the SDK. Fix that.
* Turns out Okta does not accept rotation mode changes on create, it simply ignores them. Make sure we run update for non-default scenarios.

Fixes #299, #287 