### PR TITLE
Fix wrong return of resourceAppGroupAssignmentUpdate

### DIFF
--- a/okta/resource_okta_app_group_assignment.go
+++ b/okta/resource_okta_app_group_assignment.go
@@ -101,7 +101,7 @@ func resourceAppGroupAssignmentUpdate(d *schema.ResourceData, m interface{}) err
 		return err
 	}
 
-	return resourceAppUserRead(d, m)
+	return resourceAppGroupAssignmentRead(d, m)
 }
 
 func resourceAppGroupAssignmentRead(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
This error #307 still happens when updating AppGroupAssignments: 

```2019-10-29T18:19:35.438+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: -----------------------------------------------------
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: panic: interface conversion: interface {} is nil, not string
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: goroutine 20 [running]:
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: github.com/articulate/terraform-provider-okta/okta.resourceAppUserRead(0xc000143960, 0x1bd55e0, 0xc0001480e0, 0xc0002501e0, 0x14)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/src/github.com/articulate/terraform-provider-okta/okta/resource_okta_app_user.go:97 +0x256
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: github.com/articulate/terraform-provider-okta/okta.resourceAppGroupAssignmentUpdate(0xc000143960, 0x1bd55e0, 0xc0001480e0, 0x24, 0x27d9a00)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/src/github.com/articulate/terraform-provider-okta/okta/resource_okta_app_group_assignment.go:104 +0x206
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc0002e6680, 0xc000518690, 0xc0005d8ae0, 0x1bd55e0, 0xc0001480e0, 0x1, 0xc000542fc0, 0x100e8a3)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/helper/schema/resource.go:311 +0x263
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc000108c80, 0xc00024d918, 0xc000518690, 0xc0005d8ae0, 0xc0004a81c8, 0xc0000d2701, 0x1bce8c0)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/helper/schema/provider.go:294 +0x99
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc0000a8150, 0x200b920, 0xc000542240, 0xc0002b8120, 0xc0000a8150, 0xc000542240, 0xc0001aea80)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/internal/helper/plugin/grpc_provider.go:885 +0x882
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x1d1dda0, 0xc0000a8150, 0x200b920, 0xc000542240, 0xc0002b80c0, 0x0, 0x200b920, 0xc000542240, 0xc00012a000, 0x161)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/internal/tfplugin5/tfplugin5.pb.go:3189 +0x217
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000d62c0, 0x2018860, 0xc00007b380, 0xc00001d600, 0xc0004cb410, 0x27ad700, 0x0, 0x0, 0x0)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995 +0x460
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: google.golang.org/grpc.(*Server).handleStream(0xc0000d62c0, 0x2018860, 0xc00007b380, 0xc00001d600, 0x0)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275 +0xd97
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0000c2050, 0xc0000d62c0, 0x2018860, 0xc00007b380, 0xc00001d600)
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710 +0xbb
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: created by google.golang.org/grpc.(*Server).serveStreams.func1
2019-10-29T18:19:35.440+0100 [DEBUG] plugin.terraform-provider-okta_v3.0.30_x4: 	/Users/walden/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:708 +0xa1
2019/10/29 18:19:35 [DEBUG] okta_app_group_assignment.play_milano: apply errored, but we're indicating that via the Error pointer rather than returning it: rpc error: code = Unavailable desc = transport is closing
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalMaybeTainted
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalWriteState
2019/10/29 18:19:35 [TRACE] EvalWriteState: writing current state object for okta_app_group_assignment.play_milano
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalApplyProvisioners
2019/10/29 18:19:35 [TRACE] EvalApplyProvisioners: okta_app_group_assignment.play_milano is not freshly-created, so no provisioning is required
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalMaybeTainted
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalWriteState
2019/10/29 18:19:35 [TRACE] EvalWriteState: writing current state object for okta_app_group_assignment.play_milano
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalIf
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalIf
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalWriteDiff
2019/10/29 18:19:35 [TRACE] <root>: eval: *terraform.EvalApplyPost
2019-10-29T18:19:35.443+0100 [DEBUG] plugin: plugin process exited: path=/Users/fllaca/.terraform.d/plugins/terraform-provider-okta_v3.0.30_x4 pid=17746 error="exit status 2"
2019/10/29 18:19:35 [ERROR] <root>: eval: *terraform.EvalApplyPost, err: rpc error: code = Unavailable desc = transport is closing
2019/10/29 18:19:35 [ERROR] <root>: eval: *terraform.EvalSequence, err: rpc error: code = Unavailable desc = transport is closing
```