### PR TITLE
Document the need for lifecycle argument

### DIFF
--- a/website/docs/r/app_group_assignment.html.markdown
+++ b/website/docs/r/app_group_assignment.html.markdown
@@ -12,6 +12,14 @@ Assigns a group to an application.
 
 This resource allows you to create an App Group assignment.
 
+__When using this resource, make sure to add the following `lifefycle` argument to the application resource you are assigning to:__
+
+```hcl
+lifecycle {
+  ignore_changes = ["groups"]
+}
+```
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/app_user.html.markdown
+++ b/website/docs/r/app_user.html.markdown
@@ -12,6 +12,14 @@ Creates an Application User.
 
 This resource allows you to create and configure an Application User.
 
+__When using this resource, make sure to add the following `lifefycle` argument to the application resource you are assigning to:__
+
+```hcl
+lifecycle {
+  ignore_changes = ["users"]
+}
+```
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
When managing application group assignments via `app_group_assignment` resource
the application resource's group management must be disabled using `lifecycle.ignore_changes`
attribute to avoid removal of externally added assignments. Same applies
to `app_user` resource.

While this behaviour is shown in examples, it is best to warn users by
adding this to docs too.

See #322