### PR TITLE
Rework okta_policy_mfa factors

### DIFF
--- a/examples/okta_policy_mfa/basic.tf
+++ b/examples/okta_policy_mfa/basic.tf
@@ -7,7 +7,7 @@ resource okta_policy_mfa test {
   status      = "ACTIVE"
   description = "Terraform Acceptance Test MFA Policy"
 
-  okta_otp = {
+  okta_otp {
     enroll = "REQUIRED"
   }
 

--- a/examples/okta_policy_mfa/basic_updated.tf
+++ b/examples/okta_policy_mfa/basic_updated.tf
@@ -8,15 +8,15 @@ resource okta_policy_mfa test {
   description     = "Terraform Acceptance Test MFA Policy Updated"
   groups_included = ["${data.okta_group.all.id}"]
 
-  fido_u2f = {
+  fido_u2f {
     enroll = "OPTIONAL"
   }
 
-  okta_otp = {
+  okta_otp {
     enroll = "OPTIONAL"
   }
 
-  okta_sms = {
+  okta_sms {
     enroll = "OPTIONAL"
   }
 

--- a/okta/resource_okta_policy_mfa.go
+++ b/okta/resource_okta_policy_mfa.go
@@ -221,7 +221,9 @@ func buildFactorProvider(d *schema.ResourceData, key string) *articulateOkta.Fac
 
 func syncFactor(d *schema.ResourceData, k string, f *articulateOkta.FactorProvider) {
 	if f != nil {
-		d.Set(fmt.Sprintf("%s.consent_type", k), f.Consent.Type)
-		d.Set(fmt.Sprintf("%s.enroll", k), f.Enroll.Self)
+		d.Set(k, map[string]interface{}{
+			"consent_type": f.Consent.Type,
+			"enroll":       f.Enroll.Self,
+		})
 	}
 }

--- a/website/docs/r/policy_mfa.html.markdown
+++ b/website/docs/r/policy_mfa.html.markdown
@@ -20,7 +20,7 @@ resource "okta_policy_mfa" "example" {
   status      = "ACTIVE"
   description = "Example"
 
-  okta_otp = {
+  okta_otp {
     enroll = "REQUIRED"
   }
 


### PR DESCRIPTION
Currently this PR fixes some issues with the factor configuration.

Changes in summary:
- [x] Convert to a `TypeList` which allows for defining attributes
- [x] Fix read and update
- [ ] Update tests

I've not updated any tests yet because I'm not sure what is the best way to handle these, so this PR is more of a proposal.

Using `Computed` avoids getting diffs in plans for undefined (in the config) factors, eg.:
```
      - okta_otp {
          - consent_type = "NONE" -> null
          - enroll       = "NOT_ALLOWED" -> null
        }
```
However, it also means that we silently ignore the configuration for any factors that are not explicitly defined in config.

The above is also no-op due to [this check](https://github.com/articulate/terraform-provider-okta/compare/master...alkar:mfa_policy_factor_schema?expand=1#diff-ec2a98f08596e99be17b2a96d5b1a68cR204-R207) so it will appear on every plan. We can't remove this check because otherwise we would have to submit config for each factor and that will produce an API error if a factor is not enabled.

Ideally, we would be able to set a default for each provider and remove `Computed` so that the plan would look (again for undefined factors) like so:
```
      ~ okta_otp {
            consent_type = "NONE"
          ~ enroll       = "NOT_ALLOWED" -> "OPTIONAL"
        }
```
Prompting the user to either define the factor explicitly or apply the changes. Unfortunately, we can't have `Default` in the schema for `TypeList` or `TypeSet`.

Any feedback and suggestions will be much appreciated!