### PR TITLE
Switch id with type in import documentation

### DIFF
--- a/website/docs/r/template_email.html.markdown
+++ b/website/docs/r/template_email.html.markdown
@@ -51,8 +51,8 @@ The following arguments are supported:
 
 ## Import
 
-An Okta Email Template can be imported via the Okta ID.
+An Okta Email Template can be imported via the template type.
 
 ```
-$ terraform import okta_template_email.example <template id>
+$ terraform import okta_template_email.example <template type>
 ```


### PR DESCRIPTION
The documentation incorrectly shows that the okta id is used to import email templates. The current implementation uses the email template type.

I tested with ids and it failed, then with types and they succeeded.