### PR TITLE
Allow user to be retrieved by id

### DIFF
--- a/examples/okta_user/datasource.tf
+++ b/examples/okta_user/datasource.tf
@@ -39,3 +39,7 @@ data okta_user test {
     value = "${okta_user.test.last_name}"
   }
 }
+
+data okta_user read_by_id {
+  user_id = "${okta_user.test.id}"
+}

--- a/okta/data_source_okta_user.go
+++ b/okta/data_source_okta_user.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/okta/okta-sdk-golang/okta"
 	"github.com/okta/okta-sdk-golang/okta/query"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func dataSourceUser() *schema.Resource {
@@ -15,23 +17,69 @@ func dataSourceUser() *schema.Resource {
 		Read: dataSourceUserRead,
 
 		Schema: buildUserDataSourceSchema(map[string]*schema.Schema{
-			"search": userSearchSchema,
+			"user_id": {
+				Type:        schema.TypeString,
+				Description: "Retrieve a single user based on their id",
+				Optional:    true,
+			},
+			"search": &schema.Schema{
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Filter to find a user, each filter will be concatenated with an AND clause. Please be aware profile properties must match what is in Okta, which is likely camel case",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Property name to search for. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"comparison": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "eq",
+							ValidateFunc: validation.StringInSlice([]string{"eq", "lt", "gt", "sw"}, true),
+						},
+					},
+				},
+			},
 		}),
 	}
 }
 
 func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
 	client := getOktaClientFromMetadata(m)
-	users, _, err := client.User.ListUsers(&query.Params{Search: getSearchCriteria(d), Limit: 1})
 
-	if err != nil {
-		return fmt.Errorf("Error Getting User from Okta: %v", err)
-	} else if len(users) < 1 {
-		return errors.New("failed to locate user with provided parameters")
+	var user *okta.User
+	var err error
+
+	userId, userIdOk := d.GetOk("user_id")
+	_, searchCriteriaOk := d.GetOk("search")
+
+	if userIdOk {
+		user, _, err = client.User.GetUser(userId.(string))
+		if err != nil {
+			return err
+		}
+	} else if searchCriteriaOk {
+		var users []*okta.User
+		users, _, err := client.User.ListUsers(&query.Params{Search: getSearchCriteria(d), Limit: 1})
+
+		if err != nil {
+			return err
+		} else if len(users) < 1 {
+			return errors.New("failed to locate user with provided parameters")
+		}
+
+		user = users[0]
 	}
 
-	d.SetId(users[0].Id)
-	rawMap, err := flattenUser(users[0], d)
+	d.SetId(user.Id)
+
+	rawMap, err := flattenUser(user, d)
 	if err != nil {
 		return err
 	}

--- a/okta/data_source_okta_user_test.go
+++ b/okta/data_source_okta_user_test.go
@@ -33,6 +33,8 @@ func TestAccOktaDataSourceUser_read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.okta_user.test", "first_name", "TestAcc"),
 					resource.TestCheckResourceAttr("data.okta_user.test", "last_name", "Smith"),
 					resource.TestCheckResourceAttrSet("okta_user.test", "id"),
+					resource.TestCheckResourceAttr("data.okta_user.read_by_id", "first_name", "TestAcc"),
+					resource.TestCheckResourceAttr("data.okta_user.read_by_id", "last_name", "Smith"),
 				),
 			},
 		},

--- a/okta/data_source_okta_users.go
+++ b/okta/data_source_okta_users.go
@@ -6,6 +6,7 @@ import (
 	"github.com/articulate/terraform-provider-okta/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/okta/okta-sdk-golang/okta"
 	"github.com/okta/okta-sdk-golang/okta/query"
 )
@@ -15,7 +16,30 @@ func dataSourceUsers() *schema.Resource {
 		Read: dataSourceUsersRead,
 
 		Schema: map[string]*schema.Schema{
-			"search": userSearchSchema,
+			"search": &schema.Schema{
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "Filter to find a user, each filter will be concatenated with an AND clause. Please be aware profile properties must match what is in Okta, which is likely camel case",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Property name to search for. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"comparison": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "eq",
+							ValidateFunc: validation.StringInSlice([]string{"eq", "lt", "gt", "sw"}, true),
+						},
+					},
+				},
+			},
 			"users": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,

--- a/okta/user.go
+++ b/okta/user.go
@@ -5,38 +5,12 @@ import (
 	"fmt"
 	"github.com/articulate/terraform-provider-okta/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/okta/okta-sdk-golang/okta"
 	"log"
 	"net/http"
 	"reflect"
 	"time"
 )
-
-var userSearchSchema = &schema.Schema{
-	Type:        schema.TypeSet,
-	Required:    true,
-	Description: "Filter to find a user, each filter will be concatenated with an AND clause. Please be aware profile properties must match what is in Okta, which is likely camel case",
-	Elem: &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Property name to search for. This requires the search feature be on. Please see Okta documentation on their filter API for users. https://developer.okta.com/docs/api/resources/users#list-users-with-search",
-			},
-			"value": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"comparison": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "eq",
-				ValidateFunc: validation.StringInSlice([]string{"eq", "lt", "gt", "sw"}, true),
-			},
-		},
-	},
-}
 
 var userProfileDataSchema = map[string]*schema.Schema{
 	"admin_roles": &schema.Schema{

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -13,6 +13,12 @@ Use this data source to retrieve a users from Okta.
 ## Example Usage
 
 ```hcl
+# Get a single user by their id value
+data "okta_user" "example" {
+  user_id = "00u22mtxlrJ8YkzXQ357"
+}
+
+# Search for a single user based on supported profile properties
 data "okta_user" "example" {
   search {
     name  = "profile.firstName"
@@ -28,7 +34,9 @@ data "okta_user" "example" {
 
 ## Arguments Reference
 
-* `search` - (Required) Map of search criteria. It supports the following properties.
+* `user_id` - (Optional) String representing a specific user's id value
+
+* `search` - (Optional) Map of search criteria. It supports the following properties.
   * `name` - (Required) Name of property to search against.
   * `comparison` - (Optional) Comparison to use.
   * `value` - (Required) Value to compare with.


### PR DESCRIPTION
Fixes #336 

I've added an additional optional attribute to the user data source called `user_id`. We can now search for a single user like so:

```
data "okta_user" "example" {
  user_id = "00u22mtxlrJ8YkzXQ357"
}
```

Examples & documentation are updated, and I've run acceptance tests for the user & users data sources. Let me know if I've missed anything and feel free to nitpick! This is my first time with Go, Terraform and Okta. 