### PR TITLE
Add support for token_endpoint_auth_method = private_key_jwt

### DIFF
--- a/examples/okta_app_oauth/service_with_jwks.tf
+++ b/examples/okta_app_oauth/service_with_jwks.tf
@@ -1,0 +1,14 @@
+resource "okta_app_oauth" "test" {
+  label          = "testAcc_replace_with_uuid"
+  type           = "service"
+  response_types = ["token"]
+  grant_types    = ["client_credentials"]
+  token_endpoint_auth_method = "private_key_jwt"
+
+  jwks {
+    kty = "RSA"
+    kid = "SIGNING_KEY"
+    e   = "AQAB"
+    n   = "xyz"
+  }
+}

--- a/sdk/app_oidc_models.go
+++ b/sdk/app_oidc_models.go
@@ -1,0 +1,44 @@
+package sdk
+
+import (
+	"github.com/okta/okta-sdk-golang/okta"
+)
+
+type (
+	OpenIdConnectApplication struct {
+		okta.OpenIdConnectApplication
+		Settings *OpenIdConnectApplicationSettings `json:"settings,omitempty"`
+	}
+
+	OpenIdConnectApplicationSettings struct {
+		okta.OpenIdConnectApplicationSettingsClient
+		OauthClient *OpenIdConnectApplicationSettingsClient `json:"oauthClient,omitempty"`
+	}
+
+	OpenIdConnectApplicationSettingsClient struct {
+		okta.OpenIdConnectApplicationSettingsClient
+		JWKS *JWKS `json:"jwks,string"`
+	}
+
+	JWKS struct {
+		Keys []*JWK `json:"keys,omitempty"`
+	}
+
+	JWK struct {
+		Type     string `json:"kty,omitempty"`
+		ID       string `json:"kid,omitempty"`
+		Exponent string `json:"e,omitempty"`
+		Modulus  string `json:"n,omitempty"`
+	}
+)
+
+func NewOpenIdConnectApplication() *OpenIdConnectApplication {
+	app := &OpenIdConnectApplication{}
+	app.Name = "oidc_client"
+	app.SignOnMode = "OPENID_CONNECT"
+	return app
+}
+
+func (a *OpenIdConnectApplication) IsApplicationInstance() bool {
+	return true
+}

--- a/sdk/app_oidc_models.go
+++ b/sdk/app_oidc_models.go
@@ -17,7 +17,7 @@ type (
 
 	OpenIdConnectApplicationSettingsClient struct {
 		okta.OpenIdConnectApplicationSettingsClient
-		JWKS *JWKS `json:"jwks,string"`
+		JWKS *JWKS `json:"jwks,omitempty"`
 	}
 
 	JWKS struct {


### PR DESCRIPTION
This isn't particularly well documented by Okta. You'll see it listed
under https://developer.okta.com/docs/reference/api/apps/#credentials -
and an example including the JWKS elements is available here:
https://developer.okta.com/docs/reference/api/apps/#request-example-10

The general idea behind this is described at
https://developer.okta.com/docs/reference/api/oidc/#jwt-with-private-key
\- basically, a private key is held client side. The associated public
key is provided to Okta. Client authentication is achieved by signing a
JWT containing the appropriate client ID. Okta then check the JWT was
signed using one of the keys associated with that client.

As seems to be the case with quite a few things, this isn't covered by
their SDK. I've tried to work around this by defining structs under the
SDK package and embedding the original structs. If this doesn't seem
overly suitable, we'll just have to wait for these bits to be reflected
in the official SDK.

In terms of naming - the JWKS spec uses short key names for various bits
\- these do map to suitable english equivalents, but I sort of get the
impression people are mostly used to the short forms.. and requiring
people to map them might be a bit of a nuisance. Happy to change that
if anyone feels strongly.

Some properties are dependent on the key type. For example, with RSA
"e" + "n" are required by the Okta API. Happy to get any pointers on
how to require these in schema _only if the key type is RSA_. I believe
Okta support kty = EC (Elliptic Curve) with "x" + "y" properties - if
so this can be expanded in the future.

Final note - I've used the list type here - it seems the set type would
work too, I'm not sure what the advantages of using one over the other
are in a terraform setting - happy to adjust.

---

As per https://github.com/articulate/terraform-provider-okta/blob/master/DEVELOPMENT.md#creating-a-pr - I've not been able to run all the acceptance tests - I can show you the tests in okta/resource_okta_app_oauth_test.go passing:

![pass](https://raw.githubusercontent.com/utilitywarehouse/terraform-provider-okta/70428c90485f0f98abcd69d35fbca74aade72000/passing.png)