### PR TITLE
Enable setting client_id for resource_okta_app_oauth

### DIFF
--- a/examples/okta_app_oauth/basic.tf
+++ b/examples/okta_app_oauth/basic.tf
@@ -5,6 +5,6 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
-  custom_client_id           = "something_from_somewhere"
+  client_id           = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 }

--- a/examples/okta_app_oauth/basic.tf
+++ b/examples/okta_app_oauth/basic.tf
@@ -5,6 +5,6 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
-  client_id           = "something_from_somewhere"
+  client_id                  = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 }

--- a/examples/okta_app_oauth/custom_attributes.tf
+++ b/examples/okta_app_oauth/custom_attributes.tf
@@ -5,7 +5,7 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
-  client_id           = "something_from_somewhere"
+  client_id                  = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 
   profile = <<JSON

--- a/examples/okta_app_oauth/custom_attributes.tf
+++ b/examples/okta_app_oauth/custom_attributes.tf
@@ -5,7 +5,7 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
-  custom_client_id           = "something_from_somewhere"
+  client_id           = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 
   profile = <<JSON

--- a/examples/okta_app_oauth/remove_custom_attributes.tf
+++ b/examples/okta_app_oauth/remove_custom_attributes.tf
@@ -5,6 +5,6 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
-  custom_client_id           = "something_from_somewhere"
+  client_id           = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 }

--- a/examples/okta_app_oauth/remove_custom_attributes.tf
+++ b/examples/okta_app_oauth/remove_custom_attributes.tf
@@ -5,6 +5,6 @@ resource "okta_app_oauth" "test" {
   redirect_uris              = ["http://d.com/"]
   response_types             = ["code"]
   client_basic_secret        = "something_from_somewhere"
-  client_id           = "something_from_somewhere"
+  client_id                  = "something_from_somewhere"
   token_endpoint_auth_method = "client_secret_basic"
 }

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -437,7 +437,12 @@ func buildAppOAuth(d *schema.ResourceData, m interface{}) *okta.OpenIdConnectApp
 	}
 
 	if cid, ok := d.GetOk("custom_client_id"); ok {
-		app.Credentials.OauthClient.ClientId = cid.(string)
+		// client_id, if set, gets precedence
+		// this will force recreation for clients that specify both `client_id` and `custom_client_id`, but not
+		// if they're the same
+		if d.Get("client_id").(string) == "" {
+			app.Credentials.OauthClient.ClientId = cid.(string)
+		}
 	}
 
 	app.Settings = &okta.OpenIdConnectApplicationSettings{

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -103,14 +103,16 @@ func resourceAppOAuth() *schema.Resource {
 			},
 			"client_id": &schema.Schema{
 				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "OAuth client ID.",
+				Optional:    true,
+				ForceNew:    true,
+				Description: "OAuth client ID. If set during creation, app is created with this id.",
 			},
 			"custom_client_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "This property allows you to set your client_id.",
+				Deprecated:  "Set the client_id instead",
 			},
 			"omit_secret": &schema.Schema{
 				Type:     schema.TypeBool,

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -103,7 +103,7 @@ func resourceAppOAuth() *schema.Resource {
 			},
 			"client_id": &schema.Schema{
 				Type: schema.TypeString,
-				// This field is Optional + Computed because we automatically set the
+				// This field is Optional + Computed because okta automatically sets the
 				// client_id value if none is specified during creation.
 				// If the client_id is set after creation, the resource will be recreated only if its different from
 				// the computed client_id.

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -105,6 +105,7 @@ func resourceAppOAuth() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 				Description: "OAuth client ID. If set during creation, app is created with this id.",
 			},
 			"custom_client_id": &schema.Schema{

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -107,11 +107,10 @@ func resourceAppOAuth() *schema.Resource {
 				// client_id value if none is specified during creation.
 				// If the client_id is set after creation, the resource will be recreated only if its different from
 				// the computed client_id.
-				Optional:      true,
-				ConflictsWith: []string{"custom_client_id"},
-				ForceNew:      true,
-				Computed:      true,
-				Description:   "OAuth client ID. If set during creation, app is created with this id.",
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: "OAuth client ID. If set during creation, app is created with this id.",
 			},
 			"custom_client_id": &schema.Schema{
 				Type:          schema.TypeString,

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -442,8 +442,8 @@ func buildAppOAuth(d *schema.ResourceData, m interface{}) *okta.OpenIdConnectApp
 		app.Credentials.OauthClient.ClientSecret = sec.(string)
 	}
 
-	if ccid, ok := d.GetOk("custom_client_id"); ok {
-		app.Credentials.OauthClient.ClientId = ccid.(string)
+	if cid, ok := d.GetOk("custom_client_id"); ok {
+		app.Credentials.OauthClient.ClientId = cid.(string)
 	}
 
 	app.Settings = &okta.OpenIdConnectApplicationSettings{

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -474,3 +474,5 @@ func buildAppOAuth(d *schema.ResourceData, m interface{}) *okta.OpenIdConnectApp
 
 	return app
 }
+
+func getClusterID() {}

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"encoding/json"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/okta/okta-sdk-golang/okta"

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -116,8 +116,7 @@ func resourceAppOAuth() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"client_id"},
-				ForceNew:      true,
-				Description:   "**Deprecated** This property allows you to set your client_id.",
+				Description:   "**Deprecated** This property allows you to set your client_id during creation. NOTE: updating after creation will be a no-op, use client_id for that behavior instead.",
 				Deprecated:    "This field is being replaced by client_id. Please set that field instead.",
 			},
 			"omit_secret": &schema.Schema{

--- a/okta/resource_okta_app_oauth.go
+++ b/okta/resource_okta_app_oauth.go
@@ -438,8 +438,8 @@ func buildAppOAuth(d *schema.ResourceData, m interface{}) *okta.OpenIdConnectApp
 
 	if cid, ok := d.GetOk("custom_client_id"); ok {
 		// client_id, if set, gets precedence
-		// this will force recreation for clients that specify both `client_id` and `custom_client_id`, but not
-		// if they're the same
+		// this will force recreation for clients that specify both `client_id` and `custom_client_id` iff
+		// they're the same
 		if d.Get("client_id").(string) == "" {
 			app.Credentials.OauthClient.ClientId = cid.(string)
 		}

--- a/okta/resource_okta_app_oauth_test.go
+++ b/okta/resource_okta_app_oauth_test.go
@@ -216,7 +216,7 @@ func TestAccAppOauth_customClientIDError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      buildTestOAuthAppCustomClientIDBadConfig(ri),
-				ExpectError: regexp.MustCompile(`config is invalid: 2 problems:`),
+				ExpectError: regexp.MustCompile(`config is invalid: "custom_client_id": conflicts with client_id`),
 			},
 		},
 	})

--- a/okta/resource_okta_app_oauth_test.go
+++ b/okta/resource_okta_app_oauth_test.go
@@ -205,6 +205,23 @@ func TestAccAppOauth_customClientID(t *testing.T) {
 	})
 }
 
+// TODO: remove when custom_client_id is removed
+func TestAccAppOauth_customClientIDError(t *testing.T) {
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: createCheckResourceDestroy(appOAuth, createDoesAppExist(okta.NewOpenIdConnectApplication())),
+		Steps: []resource.TestStep{
+			{
+				Config:      buildTestOAuthAppCustomClientIDBadConfig(ri),
+				ExpectError: regexp.MustCompile(`config is invalid: 2 problems:`),
+			},
+		},
+	})
+}
+
 func createDoesAppExist(app okta.App) func(string) (bool, error) {
 	return func(id string) (bool, error) {
 		client := getOktaClientFromMetadata(testAccProvider.Meta())
@@ -249,6 +266,21 @@ resource "%s" "test" {
   redirect_uris    = ["http://test.com"]
   custom_client_id = "%s"
 }`, appOAuth, name, name)
+}
+
+func buildTestOAuthAppCustomClientIDBadConfig(rInt int) string {
+	name := buildResourceName(rInt)
+
+	return fmt.Sprintf(`
+resource "%s" "test" {
+  label            = "%s"
+  type             = "service"
+  response_types   = ["token"]
+  grant_types      = ["implicit", "client_credentials"]
+  redirect_uris    = ["http://test.com"]
+  custom_client_id = "%s"
+  client_id        = "%s"
+}`, appOAuth, name, name, name)
 }
 
 func buildTestOAuthConfigBadGrantTypes(rInt int) string {

--- a/website/docs/r/app_oauth.html.markdown
+++ b/website/docs/r/app_oauth.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `groups` - (Optional) The groups assigned to the application. It is recommended not to use this and instead use `okta_app_group_assignment`.
 
-* `custom_client_id` - (Optional) This property allows you to set the application's client id.
+* `client_id` - (Optional) OAuth client ID. If set during creation, app is created with this id.
 
 * `omit_secret` - (Optional) This tells the provider not to persist the application's secret to state. If this is ever changes from true => false your app will be recreated.
 


### PR DESCRIPTION
## Description
Enables specification of `client_id` for oauth app resource. Fixes: https://github.com/articulate/terraform-provider-okta/issues/372

Following the deprecation guide in: https://www.terraform.io/docs/extend/best-practices/deprecations.html

## Breaking Behaviors
_`custom_client_id` changes does not recreate resource_: This is a change in existing provider behavior. However, its an easy way to ensure that users can migrate from `custom_client_id` to `client_id` _without recreating their apps_. To migrate, users would simply change the variables from `custom_client_id` to `client_id`, apply and done. 

The other way would be to edit in statefile, or to remove from state and import, both of which involve more effort. I believe this is a reasonable trade-off considering that the next release will remove the `custom_client_id`.

## Integration Test Run
I checked only the OAuth tests; trying to run  the whole suite gave me an OKTA rate limit error 😬. I can try running it if its really required though.

```
env OKTA_ORG_NAME=$OKTA_ORG_NAME OKTA_API_TOKEN=$OKTA_API_TOKEN OKTA_BASE_URL=$OKTA_BASE_URL TEST_FILTER=TestAccAppOauth make testac
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -run TestAccAppOauth -timeout 120m
?       github.com/articulate/terraform-provider-okta   [no test files]
=== RUN   TestAccAppOauth_basic
--- PASS: TestAccAppOauth_basic (14.81s)
=== RUN   TestAccAppOauth_serviceNative
--- PASS: TestAccAppOauth_serviceNative (13.27s)
=== RUN   TestAccAppOauth_badGrantTypes
--- PASS: TestAccAppOauth_badGrantTypes (0.07s)
=== RUN   TestAccAppOauth_customProfileAttributes
--- PASS: TestAccAppOauth_customProfileAttributes (19.39s)
=== RUN   TestAccAppOauth_customClientID
--- PASS: TestAccAppOauth_customClientID (12.53s)
=== RUN   TestAccAppOauth_customClientIDError
--- PASS: TestAccAppOauth_customClientIDError (0.03s)
PASS
ok      github.com/articulate/terraform-provider-okta/okta      61.515s
?       github.com/articulate/terraform-provider-okta/sdk       [no test files]
``` 