### PR TITLE
Official Provider Part Deux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Terraform Provider Okta
 
+## It's Official
+
+[We've moved!](https://www.terraform.io/docs/providers/okta/index.html). In an effort to provide better support for this project, Hashicorp and Okta have helped us make this an official provider.
+
 - [![Build Status](https://travis-ci.org/articulate/terraform-provider-okta.svg?branch=master)](https://travis-ci.org/articulate/terraform-provider-okta)
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)


### PR DESCRIPTION
Hashicorp has once again released this provider officially. It sounds like Okta is fully on board this time around. I updated the README to point users over there. I think it would also be helpful to have it in the repository description. I will also work on getting the issues moved over. Due to my lack of access, I may need assistance with that. 